### PR TITLE
Feat: Add 5-minute summaries

### DIFF
--- a/frontend/app/paper/[slug]/page.tsx
+++ b/frontend/app/paper/[slug]/page.tsx
@@ -491,6 +491,31 @@ export default function LayoutTestsPage() {
               </div>
             </div>
 
+            {/* 5-Minute Summary */}
+            {paperData.five_minute_summary && (
+              <div className="mb-4 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-lg shadow-md overflow-hidden">
+                <div className="p-4">
+                  <div className="flex items-center gap-2 mb-3">
+                    <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
+                    <h2 className="text-lg font-semibold text-blue-900 dark:text-blue-100">
+                      5-Minute Summary
+                    </h2>
+                    <span className="text-xs text-blue-600 dark:text-blue-400 bg-blue-100 dark:bg-blue-900/50 px-2 py-1 rounded-full">
+                      ⚡ Quick read
+                    </span>
+                  </div>
+                  <div className="prose dark:prose-invert max-w-none">
+                    <ReactMarkdown
+                      remarkPlugins={[remarkGfm, remarkMath]}
+                      rehypePlugins={[[rehypeKatex, { strict: false, throwOnError: false }]]}
+                    >
+                      {preprocessBacktickedMath(paperData.five_minute_summary)}
+                    </ReactMarkdown>
+                  </div>
+                </div>
+              </div>
+            )}
+
             <div className="flex flex-col space-y-6 flex-grow">
               {paperData.sections.map((section: Section, idx: number) => {
                 const sectionId = `sec-${idx}`;

--- a/frontend/app/paper/[slug]/page.tsx
+++ b/frontend/app/paper/[slug]/page.tsx
@@ -12,6 +12,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
+import React from 'react';
 
 // Minimal approach: convert backticked segments that look like TeX into $...$
 const preprocessBacktickedMath = (src: string): string => {
@@ -525,7 +526,7 @@ export default function LayoutTestsPage() {
 
             {/* 5-Minute Summary */}
             {paperData.five_minute_summary && (
-              <div ref={summaryRef} className="mb-4 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-lg shadow-md overflow-hidden">
+              <div ref={summaryRef} className="mb-8 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-lg shadow-md overflow-hidden">
                 <div className="p-4">
                   <div className="flex items-center gap-2 mb-3">
                     <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
@@ -562,21 +563,23 @@ export default function LayoutTestsPage() {
                     </span>
                   )}
                 </div>
-                <div className="prose dark:prose-invert max-w-none">
+                <div>
                   {paperData.sections.map((section: Section, idx: number) => {
                     const sectionId = `sec-${idx}`;
                     const isLastSection = idx === paperData.sections.length - 1;
 
                     return (
-                      <div
-                        key={section.section_title + '-' + idx}
-                        ref={(el) => { sectionRefs.current[sectionId] = el; }}
-                      >
-                        {renderRewrittenSectionContent(section)}
-                        {!isLastSection && (
-                          <hr className="my-6" />
-                        )}
-                      </div>
+                      <React.Fragment key={section.section_title + '-' + idx}>
+                        <div
+                          ref={(el) => {
+                            sectionRefs.current[sectionId] = el;
+                          }}
+                          className="prose dark:prose-invert max-w-none"
+                        >
+                          {renderRewrittenSectionContent(section)}
+                        </div>
+                        {!isLastSection && <hr className="my-6" />}
+                      </React.Fragment>
                     );
                   })}
                 </div>

--- a/frontend/app/paper/[slug]/page.tsx
+++ b/frontend/app/paper/[slug]/page.tsx
@@ -33,6 +33,7 @@ export default function LayoutTestsPage() {
   const [similarItems, setSimilarItems] = useState<Array<{ key: string; title: string | null; authors: string | null; thumbnail_data_url: string | null; slug: string | null }>>([]);
   const abortRef = useRef<AbortController | null>(null);
   const mainRef = useRef<HTMLDivElement | null>(null);
+  const summaryRef = useRef<HTMLDivElement | null>(null);
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
   const [activeSectionId, setActiveSectionId] = useState<string | null>(null);
   const [footerOverlap, setFooterOverlap] = useState<number>(0);
@@ -187,16 +188,21 @@ export default function LayoutTestsPage() {
       const anchorY = 72; // approx navbar + padding
       let bestId: string | null = null;
       let bestDelta = Number.POSITIVE_INFINITY;
-      paperData.sections.forEach((_, idx) => {
-        const id = `sec-${idx}`;
-        const el = sectionRefs.current[id];
-        if (!el) return;
-        const delta = Math.abs(el.getBoundingClientRect().top - anchorY);
+
+      const allCheckableSections = [
+        { id: 'sec-summary', element: summaryRef.current },
+        ...paperData.sections.map((_, idx) => ({ id: `sec-${idx}`, element: sectionRefs.current[`sec-${idx}`] })),
+      ];
+
+      allCheckableSections.forEach(({ id, element }) => {
+        if (!element) return;
+        const delta = Math.abs(element.getBoundingClientRect().top - anchorY);
         if (delta < bestDelta) {
           bestDelta = delta;
           bestId = id;
         }
       });
+
       if (bestId && bestId !== activeSectionId) setActiveSectionId(bestId);
     };
 
@@ -243,12 +249,11 @@ export default function LayoutTestsPage() {
     const figures = paperData?.figures || [];
     
     return (
-      <div key={section.section_title} className="prose dark:prose-invert max-w-none mb-6 last:mb-0">
+      <>
         {!section.rewritten_content && section.level === 1 && (
           <h4 className="font-semibold">{section.section_title} (p. {section.start_page}-{section.end_page})</h4>
         )}
         {section.rewritten_content && (
-          <div className="mt-2">
             <ReactMarkdown
               remarkPlugins={[remarkGfm, remarkMath]}
               rehypePlugins={[[rehypeKatex, { strict: false, throwOnError: false }]]}
@@ -312,9 +317,8 @@ export default function LayoutTestsPage() {
             >
               {preprocessBacktickedMath(section.rewritten_content || '')}
             </ReactMarkdown>
-          </div>
         )}
-      </div>
+      </>
     );
   };
 
@@ -416,32 +420,60 @@ export default function LayoutTestsPage() {
           style={{ height: `calc(100vh - ${footerOverlap}px - 2rem)` }}
         >
           <div className="h-full overflow-y-auto p-4">
-              <h2 className="text-xl font-semibold mb-4">Sections</h2>
               {paperData ? (
-                <ul className="space-y-1">
-                  {paperData.sections.map((section: Section, idx: number) => {
-                    const id = `sec-${idx}`;
-                    const isActive = activeSectionId === id;
-                    return (
-                      <li key={id}>
-                        <button
-                          className={`w-full text-left px-3 py-2 rounded-md text-sm transition-colors ${
-                            isActive ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200'
-                          }`}
-                          onClick={() => {
-                            const el = sectionRefs.current[id];
-                            el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                            setActiveSectionId(id);
-                          }}
-                          title={`Go to ${section.section_title}`}
-                        >
-                          <span className="mr-2 font-semibold">{idx + 1}.</span>
-                          <span>{section.section_title || `Section ${idx + 1}`}</span>
-                        </button>
-                      </li>
-                    );
-                  })}
-                </ul>
+                <>
+                  {paperData.five_minute_summary && (
+                    <div className="mb-6">
+                      <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-200">5-Minute Summary</h2>
+                      <div className="border-b border-gray-200 dark:border-gray-700 mb-2"></div>
+                      <ul className="space-y-1">
+                        <li>
+                          <button
+                            className={`w-full text-left px-3 py-2 rounded-md text-sm transition-colors ${
+                              activeSectionId === 'sec-summary' ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200'
+                            }`}
+                            onClick={() => {
+                              summaryRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                              setActiveSectionId('sec-summary');
+                            }}
+                            title="Go to 5-Minute Summary"
+                          >
+                            Summary
+                          </button>
+                        </li>
+                      </ul>
+                    </div>
+                  )}
+
+                  <div>
+                    <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-200">Simplified Version</h2>
+                    <div className="border-b border-gray-200 dark:border-gray-700 mb-2"></div>
+                    <ul className="space-y-1">
+                      {paperData.sections.map((section: Section, idx: number) => {
+                        const id = `sec-${idx}`;
+                        const isActive = activeSectionId === id;
+                        return (
+                          <li key={id}>
+                            <button
+                              className={`w-full text-left px-3 py-2 rounded-md text-sm transition-colors ${
+                                isActive ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200'
+                              }`}
+                              onClick={() => {
+                                const el = sectionRefs.current[id];
+                                el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                                setActiveSectionId(id);
+                              }}
+                              title={`Go to ${section.section_title}`}
+                            >
+                              <span className="mr-2 font-semibold">{idx + 1}.</span>
+                              <span>{section.section_title || `Section ${idx + 1}`}</span>
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </div>
+                </>
               ) : (
                 <div className="text-sm text-gray-500 dark:text-gray-400">Loading sections…</div>
               )}
@@ -493,7 +525,7 @@ export default function LayoutTestsPage() {
 
             {/* 5-Minute Summary */}
             {paperData.five_minute_summary && (
-              <div className="mb-4 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-lg shadow-md overflow-hidden">
+              <div ref={summaryRef} className="mb-4 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-lg shadow-md overflow-hidden">
                 <div className="p-4">
                   <div className="flex items-center gap-2 mb-3">
                     <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
@@ -516,20 +548,39 @@ export default function LayoutTestsPage() {
               </div>
             )}
 
-            <div className="flex flex-col space-y-6 flex-grow">
-              {paperData.sections.map((section: Section, idx: number) => {
-                const sectionId = `sec-${idx}`;
+            {/* Simplified Version */}
+            <div className="mb-4 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg shadow-md overflow-hidden">
+              <div className="p-4">
+                <div className="flex items-center gap-2 mb-3">
+                  <div className="w-2 h-2 bg-gray-500 rounded-full"></div>
+                  <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                    Simplified Version
+                  </h2>
+                  {typeof readingMinutes === 'number' && (
+                    <span className="text-xs text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded-full">
+                      📖 {readingMinutes} min read
+                    </span>
+                  )}
+                </div>
+                <div className="prose dark:prose-invert max-w-none">
+                  {paperData.sections.map((section: Section, idx: number) => {
+                    const sectionId = `sec-${idx}`;
+                    const isLastSection = idx === paperData.sections.length - 1;
 
-                return (
-                  <div
-                    key={section.section_title + '-' + idx}
-                    ref={(el) => { sectionRefs.current[sectionId] = el; }}
-                    className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg shadow-md overflow-hidden p-4"
-                  >
-                    {renderRewrittenSectionContent(section)}
-                  </div>
-                );
-              })}
+                    return (
+                      <div
+                        key={section.section_title + '-' + idx}
+                        ref={(el) => { sectionRefs.current[sectionId] = el; }}
+                      >
+                        {renderRewrittenSectionContent(section)}
+                        {!isLastSection && (
+                          <hr className="my-6" />
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
             </div>
           </>
         ) : (

--- a/frontend/types/paper.ts
+++ b/frontend/types/paper.ts
@@ -42,6 +42,7 @@ export interface Paper {
   authors?: string | null;
   arxiv_url?: string | null;
   thumbnail_data_url?: string | null;
+  five_minute_summary?: string | null;
   sections: Section[];
   tables: Table[];
   figures: Figure[];

--- a/paperprocessor/client.py
+++ b/paperprocessor/client.py
@@ -13,6 +13,7 @@ from paperprocessor.internals.metadata_extractor import extract_metadata
 from paperprocessor.internals.structure_extractor import extract_structure
 from paperprocessor.internals.header_formatter import format_headers, format_images
 from paperprocessor.internals.section_rewriter import rewrite_sections
+from paperprocessor.internals.summary_generator import generate_five_minute_summary
 from shared.db import SessionLocal
 from papers.client import get_paper_metadata, get_processed_result_path
 
@@ -213,6 +214,10 @@ async def process_paper_pdf(pdf_contents: bytes, paper_id: Optional[str] = None)
         # Step 5: Rewrite sections - modifies document in place
         logger.info("Step 5: Rewriting sections.")
         await rewrite_sections(document)
+        
+        # Step 6: Generate 5-minute summary - modifies document in place
+        logger.info("Step 6: Generating 5-minute summary.")
+        await generate_five_minute_summary(document)
         
         logger.info("Paper processing pipeline v2 finished.")
         return document

--- a/paperprocessor/internals/summary_generator.py
+++ b/paperprocessor/internals/summary_generator.py
@@ -1,0 +1,72 @@
+import logging
+import os
+from typing import Optional
+
+from shared.openrouter import client as openrouter_client
+from paperprocessor.models import ProcessedDocument, ApiCallCostForStep
+
+logger = logging.getLogger(__name__)
+
+
+### CONSTANTS ###
+SUMMARY_MODEL = "google/gemini-2.5-pro"
+
+
+### PUBLIC API ###
+async def generate_five_minute_summary(document: ProcessedDocument) -> None:
+    """
+    Generate a 5-minute accessible summary from rewritten document content.
+    
+    Takes the rewritten_final_markdown and creates a concise, accessible summary
+    suitable for general audiences. Modifies the document in place by setting
+    the five_minute_summary field.
+    
+    Args:
+        document: ProcessedDocument with rewritten_final_markdown content
+        
+    Raises:
+        RuntimeError: If rewritten_final_markdown is missing or empty
+        RuntimeError: If LLM response is empty
+    """
+    logger.info("Generating 5-minute summary from rewritten content...")
+    
+    # Step 1: Validate input
+    if not document.rewritten_final_markdown:
+        raise RuntimeError("Cannot generate summary: rewritten_final_markdown is missing or empty")
+    
+    if document.rewritten_final_markdown.strip() == "":
+        raise RuntimeError("Cannot generate summary: rewritten_final_markdown is empty")
+    
+    # Step 2: Load summary generation prompt
+    prompts_dir = os.path.join(os.path.dirname(__file__), '..', 'prompts')
+    prompt_path = os.path.join(prompts_dir, 'generate_5min_summary.md')
+    
+    with open(prompt_path, 'r', encoding='utf-8') as f:
+        system_prompt = f.read()
+    
+    # Step 3: Generate summary using LLM
+    result = await openrouter_client.get_llm_response(
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": document.rewritten_final_markdown},
+        ],
+        model=SUMMARY_MODEL,
+    )
+    
+    # Step 4: Validate response
+    summary_text = getattr(result, "response_text", None)
+    if not summary_text or summary_text.strip() == "":
+        raise RuntimeError("Summary generation failed: LLM returned empty response")
+    
+    # Step 5: Track costs
+    step_cost = ApiCallCostForStep(
+        step_name="generate_summary",
+        model=result.model,
+        cost_info=result.cost_info
+    )
+    document.step_costs.append(step_cost)
+    
+    # Step 6: Store summary on document
+    document.five_minute_summary = summary_text.strip()
+    
+    logger.info("5-minute summary generation completed.")

--- a/paperprocessor/models.py
+++ b/paperprocessor/models.py
@@ -61,6 +61,8 @@ class ProcessedDocument:
     # Section class is defined below
     sections: List["Section"] = field(default_factory=list)
     rewritten_final_markdown: Optional[str] = None
+    # Summary generation
+    five_minute_summary: Optional[str] = None    # Accessible 5-minute summary
     # Cost tracking
     step_costs: List[ApiCallCostForStep] = field(default_factory=list)
 

--- a/paperprocessor/prompts/generate_5min_summary.md
+++ b/paperprocessor/prompts/generate_5min_summary.md
@@ -30,6 +30,8 @@ You are a technical writer creating a 5-minute summary of a research paper. Your
    - Impact on the field or industry
    - Future applications or research directions
 
+Use level 2 formatting (##) for each section inside the summary. Do not add a level 1 heading.
+
 ## Writing Guidelines
 
 - **Length**: Aim for 500-700 words total (truly readable in 5 minutes)

--- a/paperprocessor/prompts/generate_5min_summary.md
+++ b/paperprocessor/prompts/generate_5min_summary.md
@@ -1,0 +1,48 @@
+# Generate 5-Minute Paper Summary
+
+You are a technical writer creating a 5-minute summary of a research paper. Your goal is to make complex research accessible to a general audience while preserving the core insights and contributions.
+
+## Target Audience
+- General readers with basic technical literacy
+- People who want to understand the paper's value without reading the full text
+- Professionals from related fields seeking quick insights
+
+## Content Requirements
+
+**Structure your summary with these sections:**
+
+1. **What This Paper Is About** (1-2 paragraphs)
+   - Main research question or problem being solved
+   - Why this problem matters
+
+2. **Key Approach** (1-2 paragraphs)
+   - How the researchers tackled the problem
+   - Main methodology or technique used
+   - What makes their approach novel or different
+
+3. **Main Findings** (1-2 paragraphs)
+   - Core results and discoveries
+   - Key data points or performance metrics
+   - Most important conclusions
+
+4. **Why This Matters** (1 paragraph)
+   - Real-world implications
+   - Impact on the field or industry
+   - Future applications or research directions
+
+## Writing Guidelines
+
+- **Length**: Aim for 500-700 words total (truly readable in 5 minutes)
+- **Language**: Use clear, straightforward language. Explain technical terms when necessary
+- **Tone**: Engaging but professional, avoid academic jargon
+- **Focus**: Emphasize practical significance and broader impact
+- **Structure**: Use clear headings and short paragraphs for easy scanning
+
+## Formatting
+
+- Use markdown headings for each section
+- Use bullet points or numbered lists where helpful for clarity
+- Bold key terms or important findings
+- Keep paragraphs short (3-4 sentences max)
+
+Return only the summary text. Do not include any other text, meta-commentary, or explanations about the summary itself.

--- a/papers/client.py
+++ b/papers/client.py
@@ -296,6 +296,7 @@ def save_paper(db: Session, processed_content: ProcessedDocument) -> Paper:
         "title": processed_content.title,
         "authors": processed_content.authors,
         "thumbnail_data_url": None,  # Will be set from first page
+        "five_minute_summary": processed_content.five_minute_summary,
         "sections": [],
         "tables": [],
         "figures": [],


### PR DESCRIPTION
## Todo list
- [x] Add 5 minute summary generation to backend
- [x] Add section for the 5 minute summary view to frontend
- [x] Improve UI so both "5 min summary" and "simplified view" can co-exist in a logical way
- [x] make summary headers consistent with section headers (2 ##)

## What

This PR adds a 5-minute summary feature that generates accessible summaries of research papers for general audiences. The paper detail page layout has been redesigned with improved navigation and better visual hierarchy. The 5-minute summary appears as a highlighted section above the simplified version, with its own navigation entry.

## Why

Simplified versions are still 20-30 min reads ;) 

## How

**5-Minute Summary Generation:**
- Added a new LLM-powered summary generator that processes the rewritten paper content
- Uses a structured prompt with specific sections: "What This Paper Is About", "Key Approach", "Main Findings", and "Why This Matters"
- Targets 500-700 words using Google Gemini 2.5 Pro for generation
- Integrates into the existing paper processing pipeline as a new step

**Frontend Layout Redesign:**
- Added a dedicated blue-highlighted container for the 5-minute summary with visual indicators
- Restructured the sidebar navigation to include the summary as a separate navigable section
- Improved section tracking and scroll behavior to handle both summary and paper sections
- Added proper spacing and visual hierarchy between summary and simplified version sections

**Integration:**
- Extended the Paper type to include the `five_minute_summary` field
- Added the summary generation step to the paper processing client
- Implemented cost tracking for the new LLM step

## How to test

Process a new paper through the pipeline and verify the 5-minute summary is generated

## Screenshots
<img width="1432" height="946" alt="Screenshot 2025-09-17 at 22 30 14" src="https://github.com/user-attachments/assets/b74fc0f6-4491-465c-882e-adc70a763aba" />


## Future work
- The formatting of the summary can be more robust. Currently, we are just saying to the LLM which format we want (level 2 headers, no level 1 header), but that can be unreliable. 
- Noticed this bug
<img width="870" height="220" alt="Screenshot 2025-09-17 at 22 24 36" src="https://github.com/user-attachments/assets/556a0a35-ddcb-44df-b1a0-1d12abbb5a73" />
