### PR TITLE
Issues with Railway writing to debug output, mounting the debugging folder

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -29,6 +29,14 @@ COPY papers /opt/airflow/papers
 COPY users /opt/airflow/users
 COPY paperprocessor /opt/airflow/paperprocessor
 
+# Create debugging output directory for paperprocessor (Railway deployment fix)
+# This resolves Permission denied errors when paperprocessor tries to write debug files
+USER root
+RUN mkdir -p /opt/airflow/paperprocessor/debugging_output && \
+    chown airflow:root /opt/airflow/paperprocessor/debugging_output && \
+    chmod 755 /opt/airflow/paperprocessor/debugging_output
+USER airflow
+
 # Make sure PATH includes airflow binaries
 ENV PATH="/home/airflow/.local/bin:$PATH"
 


### PR DESCRIPTION
## Improvements (future work):
- better to make one general debugging_output folder and have all modules write there. Sort them by date, that way we have a target for local development, and can easily delete. Also add a readme. 