### PR TITLE
Add markdown export feature and backfill DAG for legacy papers

### DIFF
--- a/airflow/dags/backfill_final_markdown_dag.py
+++ b/airflow/dags/backfill_final_markdown_dag.py
@@ -1,0 +1,391 @@
+import sys
+import pendulum
+import json
+import base64
+import io
+from datetime import datetime
+from contextlib import contextmanager
+from typing import List, Dict
+import asyncio
+
+from airflow.decorators import dag, task
+from sqlalchemy.orm import Session, defer
+
+# Add project root to Python path to find shared modules
+sys.path.insert(0, '/opt/airflow')
+
+from shared.db import SessionLocal
+from papers.db.models import PaperRecord
+from shared.arxiv.client import download_pdf
+
+# Import the processing pipeline components
+from paperprocessor.models import ProcessedDocument, ProcessedPage
+from paperprocessor.internals.mistral_ocr import extract_markdown_from_pages
+from paperprocessor.internals.header_formatter import format_headers, format_images
+
+
+### CONSTANTS ###
+
+BATCH_SIZE = 10  # Process 10 papers per batch to manage memory and API rate limits
+
+
+### DATABASE HELPERS ###
+
+@contextmanager
+def database_session():
+    """
+    Create a database session with automatic commit/rollback handling.
+
+    Yields:
+        Session: SQLAlchemy session for database operations
+
+    Raises:
+        Exception: Any database error that occurs during the transaction
+    """
+    session: Session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+### PROCESSING FUNCTIONS (simplified from process_paper_pdf) ###
+
+async def extract_final_markdown_from_pdf(pdf_contents: bytes) -> str:
+    """
+    Extract final_markdown from PDF using the same pipeline as normal processing.
+
+    This is a simplified version of process_paper_pdf that only does what we need:
+    1. OCR → markdown per page
+    2. Format headers (combine pages)
+    3. Format image references
+
+    Skips: metadata extraction, summary generation (we don't need those)
+
+    Args:
+        pdf_contents: Raw PDF bytes
+
+    Returns:
+        str: The final_markdown field (original OCR content with formatted images)
+    """
+    # Create ProcessedDocument DTO with PDF base64
+    pdf_base64 = base64.b64encode(pdf_contents).decode('utf-8')
+
+    # We need to create pages with base64 images for the image extraction to work
+    # This is required by extract_markdown_from_pages
+    from paperprocessor.internals.pdf_to_image import convert_pdf_to_images
+    images = await convert_pdf_to_images(pdf_contents)
+
+    pages = []
+    for i, image in enumerate(images):
+        page_num = i + 1
+
+        # Convert PIL Image to base64
+        buffered = io.BytesIO()
+        image.save(buffered, format="PNG")
+        img_base64 = base64.b64encode(buffered.getvalue()).decode('utf-8')
+
+        page = ProcessedPage(
+            page_number=page_num,
+            img_base64=img_base64,
+            width=image.width,
+            height=image.height
+        )
+        pages.append(page)
+
+    document = ProcessedDocument(
+        pdf_base64=pdf_base64,
+        pages=pages
+    )
+
+    # Step 1: OCR pages to markdown - populates ocr_markdown on each page
+    await extract_markdown_from_pages(document)
+
+    # Step 2: Format headers and combine pages into final_markdown
+    # This concatenates all page OCR markdown with '\n\n'.join()
+    await format_headers(document)
+
+    # Step 3: Format inline image references
+    # This replaces ![img-X.jpeg] with ![Figure shortid](shortid:xyz)
+    await format_images(document)
+
+    # Return the final_markdown (skipping metadata and summary generation)
+    return document.final_markdown
+
+
+### DAG DEFINITION ###
+
+@dag(
+    dag_id="backfill_final_markdown",
+    start_date=pendulum.datetime(2025, 1, 1, tz="UTC"),
+    schedule=None,  # Manual trigger only (one-time use)
+    catchup=False,
+    max_active_runs=1,
+    tags=["papers", "maintenance", "backfill", "one-time"],
+    doc_md="""
+    ### Backfill Final Markdown DAG
+
+    **ONE-TIME USE DAG**: Backfills the `final_markdown` field for papers that don't have it.
+
+    This DAG was created to populate the `final_markdown` field (original OCR markdown)
+    for papers that were processed before this field was added to the database schema.
+
+    **What it does:**
+    1. Finds all completed papers that don't have `final_markdown` in their JSON
+    2. Downloads the PDF from arXiv for each paper
+    3. Runs the same processing pipeline as normal (OCR + header formatting + image formatting)
+    4. Extracts only the `final_markdown` field from the result
+    5. Updates the database JSON with the new field
+    6. Generates a summary report
+
+    **Configuration (hardcoded constants):**
+    - Batch size: 10 papers per batch
+
+    **Safety:**
+    - Only processes completed papers
+    - Only processes papers without existing final_markdown
+    - Batch commits for atomicity
+    - Auto-rollback on errors
+    - Can be re-run safely (skips papers that already have final_markdown)
+
+    **Important:**
+    - This is a one-time backfill operation
+    - After all existing papers are processed, this DAG can be archived
+    - New papers will have final_markdown populated automatically during processing
+
+    **Cost Warning:**
+    - This DAG calls Mistral OCR API for each paper
+    - Costs will depend on the number of papers and pages
+    - Monitor costs during execution
+    """,
+)
+def backfill_final_markdown_dag():
+
+    @task
+    def find_papers_without_final_markdown() -> List[Dict[str, any]]:
+        """
+        Find all completed papers that don't have final_markdown in their JSON.
+
+        Returns:
+            List[Dict]: List of papers to process with metadata:
+                - paper_uuid: UUID of the paper
+                - arxiv_id: arXiv ID for downloading PDF
+                - title: Paper title for logging
+                - num_pages: Number of pages (if available)
+        """
+        print("Scanning for papers without final_markdown...")
+
+        papers_to_process = []
+
+        with database_session() as session:
+            # Query all completed papers
+            papers = session.query(PaperRecord).filter(
+                PaperRecord.status == 'completed',
+                PaperRecord.processed_content.isnot(None)
+            ).all()
+
+            print(f"Found {len(papers)} completed papers with processed content")
+
+            # Check each paper's JSON for final_markdown field
+            for paper in papers:
+                try:
+                    paper_json = json.loads(paper.processed_content)
+
+                    # Check if final_markdown exists and is not None/empty
+                    if not paper_json.get('final_markdown'):
+                        papers_to_process.append({
+                            'paper_uuid': paper.paper_uuid,
+                            'arxiv_id': paper.arxiv_id,
+                            'title': paper.title or 'Untitled',
+                            'num_pages': paper.num_pages
+                        })
+
+                except Exception as e:
+                    print(f"Error checking paper {paper.paper_uuid}: {e}")
+                    continue
+
+        print(f"Found {len(papers_to_process)} papers that need final_markdown")
+
+        if papers_to_process:
+            # Print sample of papers to process
+            sample_size = min(5, len(papers_to_process))
+            print(f"\nSample of papers to process (showing {sample_size}):")
+            for paper in papers_to_process[:sample_size]:
+                print(f"  - {paper['paper_uuid']}: {paper['arxiv_id']} - {paper['title'][:60]}...")
+
+        return papers_to_process
+
+
+    @task
+    def process_papers_batch(papers_to_process: List[Dict[str, any]]) -> List[Dict[str, any]]:
+        """
+        Process papers in batches: download PDF, run processing pipeline, update database.
+
+        Args:
+            papers_to_process: List of papers from find_papers_without_final_markdown
+
+        Returns:
+            List[Dict]: Processing results for each paper
+        """
+        if not papers_to_process:
+            print("No papers to process")
+            return []
+
+        print(f"\nStarting processing of {len(papers_to_process)} papers...")
+        print(f"Configuration: Batch size={BATCH_SIZE}")
+
+        all_results = []
+        total_papers = len(papers_to_process)
+
+        # Process in batches
+        for batch_idx in range(0, total_papers, BATCH_SIZE):
+            batch = papers_to_process[batch_idx:batch_idx + BATCH_SIZE]
+            batch_num = (batch_idx // BATCH_SIZE) + 1
+            total_batches = (total_papers + BATCH_SIZE - 1) // BATCH_SIZE
+
+            print(f"\n--- Processing batch {batch_num}/{total_batches} ({len(batch)} papers) ---")
+
+            with database_session() as session:
+                for paper_info in batch:
+                    paper_uuid = paper_info['paper_uuid']
+                    arxiv_id = paper_info['arxiv_id']
+
+                    try:
+                        # Step 1: Load paper record
+                        paper = session.query(PaperRecord).filter(
+                            PaperRecord.paper_uuid == paper_uuid
+                        ).first()
+
+                        if not paper or not paper.processed_content:
+                            print(f"  ⚠️  {paper_uuid}: Paper or processed content not found, skipping")
+                            continue
+
+                        # Step 2: Download PDF from arXiv
+                        print(f"  Downloading PDF from arXiv ({arxiv_id})...")
+                        pdf_result = asyncio.run(download_pdf(arxiv_id))
+                        pdf_bytes = pdf_result.pdf_bytes
+
+                        # Step 3: Run processing pipeline to extract final_markdown
+                        print(f"  🔍 {paper_uuid}: Running processing pipeline (OCR + formatting)...")
+                        final_markdown = asyncio.run(extract_final_markdown_from_pdf(pdf_bytes))
+
+                        markdown_length = len(final_markdown)
+                        print(f"  ✓ {paper_uuid}: Extracted {markdown_length} characters of markdown")
+
+                        # Step 4: Update processed_content JSON
+                        paper_json = json.loads(paper.processed_content)
+                        paper_json['final_markdown'] = final_markdown
+
+                        # Save back to database
+                        paper.processed_content = json.dumps(paper_json, ensure_ascii=False)
+
+                        # Log success
+                        print(f"  💾 {paper_uuid}: Updated database with final_markdown")
+
+                        # Save result
+                        result = {
+                            'paper_uuid': paper_uuid,
+                            'arxiv_id': arxiv_id,
+                            'title': paper_info['title'],
+                            'markdown_length': markdown_length,
+                            'num_pages': paper_info.get('num_pages'),
+                            'status': 'success'
+                        }
+                        all_results.append(result)
+
+                    except Exception as e:
+                        print(f"  ✗ {paper_uuid}: Error - {e}")
+                        result = {
+                            'paper_uuid': paper_uuid,
+                            'arxiv_id': arxiv_id,
+                            'title': paper_info['title'],
+                            'status': 'failed',
+                            'error': str(e)
+                        }
+                        all_results.append(result)
+                        continue
+
+                # Commit batch
+                print(f"  💾 Committing batch {batch_num}...")
+
+        successful = len([r for r in all_results if r['status'] == 'success'])
+        failed = len([r for r in all_results if r['status'] == 'failed'])
+        print(f"\n✓ Successfully processed {successful} papers ({failed} failed)")
+
+        return all_results
+
+
+    @task
+    def generate_summary_report(processing_results: List[Dict[str, any]]) -> Dict[str, any]:
+        """
+        Generate a summary report of the backfill operation.
+
+        Args:
+            processing_results: List of processing results from process_papers_batch
+
+        Returns:
+            Dict: Summary statistics
+        """
+        if not processing_results:
+            print("\nNo papers were processed")
+            return {
+                'total_processed': 0,
+                'total_successful': 0,
+                'total_failed': 0,
+                'total_markdown_chars': 0,
+                'avg_markdown_length': 0
+            }
+
+        # Calculate aggregate statistics
+        total_processed = len(processing_results)
+        successful = [r for r in processing_results if r['status'] == 'success']
+        failed = [r for r in processing_results if r['status'] == 'failed']
+
+        total_successful = len(successful)
+        total_failed = len(failed)
+
+        total_markdown_chars = sum(r.get('markdown_length', 0) for r in successful)
+        avg_markdown_length = total_markdown_chars / total_successful if total_successful > 0 else 0
+
+        # Print summary report
+        print("\n" + "=" * 70)
+        print("BACKFILL FINAL_MARKDOWN SUMMARY REPORT")
+        print("=" * 70)
+        print(f"Total papers processed:       {total_processed}")
+        print(f"Successfully updated:         {total_successful}")
+        print(f"Failed:                       {total_failed}")
+        print(f"Total markdown extracted:     {total_markdown_chars:,} characters")
+        print(f"Average markdown length:      {avg_markdown_length:,.0f} characters")
+
+        if failed:
+            print("\n--- Failed Papers ---")
+            for result in failed[:10]:  # Show first 10 failures
+                print(f"  ✗ {result['arxiv_id']}: {result.get('error', 'Unknown error')}")
+            if len(failed) > 10:
+                print(f"  ... and {len(failed) - 10} more failures")
+
+        print("=" * 70)
+
+        summary = {
+            'total_processed': total_processed,
+            'total_successful': total_successful,
+            'total_failed': total_failed,
+            'total_markdown_chars': total_markdown_chars,
+            'avg_markdown_length': round(avg_markdown_length, 0)
+        }
+
+        return summary
+
+
+    # Define task dependencies
+    papers = find_papers_without_final_markdown()
+    results = process_papers_batch(papers)
+    summary = generate_summary_report(results)
+
+
+# Instantiate the DAG
+backfill_final_markdown_dag()

--- a/frontend/app/paper/[slug]/page.tsx
+++ b/frontend/app/paper/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { listMinimalPapers } from '../../../services/api';
 import { authClient } from '../../../services/auth';
 import { isPaperInUserList } from '../../../services/users';
 import AddToListButton from '../../../components/AddToListButton';
+import CopyMarkdownButton from '../../../components/CopyMarkdownButton';
 import { Loader, ExternalLink } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -260,7 +261,7 @@ export default function LayoutTestsPage() {
       <main ref={mainRef} className="flex-1 max-w-4xl mx-auto w-full p-2 sm:p-4 flex flex-col">
         {paperData ? (
           <>
-            <div className="mb-4 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg shadow-md overflow-hidden p-3 sm:p-4">
+            <div className="mb-4 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg shadow-md p-3 sm:p-4">
               <div className="flex flex-col sm:flex-row items-start gap-3 sm:gap-4 max-w-full">
                 {(paperData as any)?.thumbnail_url && (
                   <img
@@ -269,7 +270,7 @@ export default function LayoutTestsPage() {
                     className="w-20 h-20 sm:w-24 sm:h-24 rounded-md object-cover flex-shrink-0 mx-auto sm:mx-0"
                   />
                 )}
-                <div className="min-w-0 flex-1 overflow-hidden break-words text-center sm:text-left">
+                <div className="min-w-0 flex-1 break-words text-center sm:text-left">
                   <h1 className="text-xl sm:text-2xl lg:text-3xl font-bold mb-1 break-words whitespace-normal leading-tight">{paperData.title || 'Untitled'}</h1>
                   {paperData.authors && (
                     <p className="text-sm text-gray-700 dark:text-gray-300 mb-1 break-words whitespace-normal">{paperData.authors}</p>
@@ -287,8 +288,9 @@ export default function LayoutTestsPage() {
                       Open on arXiv
                     </a>
                   )}
-                  <div className="mt-3 flex items-center gap-3">
+                  <div className="mt-3 flex flex-col sm:flex-row items-start gap-3">
                     <AddToListButton paperId={paperData.paper_id} paperTitle={paperData.title || undefined} />
+                    <CopyMarkdownButton paperUuid={paperData.paper_id} fiveMinuteSummary={paperData.five_minute_summary} />
                   </div>
                   
                 </div>

--- a/frontend/components/CopyMarkdownButton.tsx
+++ b/frontend/components/CopyMarkdownButton.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import React, { useState, useRef, useEffect } from 'react';
+import { Check, Copy, Loader, ChevronDown } from 'lucide-react';
+import { fetchPaperMarkdown } from '../services/api';
+
+type CopyMarkdownButtonProps = {
+  paperUuid: string;
+  fiveMinuteSummary?: string | null;
+};
+
+export default function CopyMarkdownButton({ paperUuid, fiveMinuteSummary }: CopyMarkdownButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState<'summary' | 'full' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
+
+  const copyToClipboard = async (text: string): Promise<void> => {
+    await navigator.clipboard.writeText(text);
+  };
+
+  const handleCopySummary = async () => {
+    console.log('handleCopySummary called');
+    if (!fiveMinuteSummary) {
+      console.log('No summary available');
+      setError('Summary not available');
+      return;
+    }
+
+    setError(null);
+
+    try {
+      console.log('Copying summary to clipboard...');
+      await copyToClipboard(fiveMinuteSummary);
+      console.log('Summary copied successfully');
+      setCopied('summary');
+      setTimeout(() => setCopied(null), 2000);
+      setIsOpen(false);
+    } catch (err) {
+      console.error('Failed to copy summary:', err);
+      setError('Failed to copy to clipboard');
+    }
+  };
+
+  const handleCopyFullDocument = async () => {
+    console.log('handleCopyFullDocument called');
+    setError(null);
+    setLoading(true);
+
+    try {
+      console.log('Fetching markdown for paper:', paperUuid);
+      const markdown = await fetchPaperMarkdown(paperUuid);
+      console.log('Markdown fetched, length:', markdown.length);
+      await copyToClipboard(markdown);
+      console.log('Full document copied successfully');
+      setCopied('full');
+      setTimeout(() => setCopied(null), 2000);
+      setIsOpen(false);
+    } catch (err: any) {
+      console.error('Failed to copy full document:', err);
+      if (err.message.includes('404')) {
+        setError('Original markdown not available for this paper');
+      } else {
+        setError('Failed to copy to clipboard');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => {
+          console.log('CopyMarkdownButton clicked! Current isOpen:', isOpen);
+          setIsOpen(!isOpen);
+          console.log('Setting isOpen to:', !isOpen);
+        }}
+        className="px-3 py-1.5 text-sm rounded-md border bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center gap-2"
+        disabled={loading}
+      >
+        {copied ? (
+          <>
+            <Check className="w-4 h-4 text-green-600 dark:text-green-400" />
+            <span>Copied!</span>
+          </>
+        ) : loading ? (
+          <>
+            <Loader className="w-4 h-4 animate-spin" />
+            <span>Loading...</span>
+          </>
+        ) : (
+          <>
+            <Copy className="w-4 h-4" />
+            <span>Copy Markdown</span>
+            <ChevronDown className="w-3 h-3" />
+          </>
+        )}
+      </button>
+
+      {(() => {
+        console.log('Dropdown render check - isOpen:', isOpen, 'loading:', loading, 'copied:', copied);
+        console.log('Should render dropdown:', isOpen && !loading && !copied);
+        return null;
+      })()}
+
+      {isOpen && !loading && !copied && (
+        <div className="absolute right-0 mt-2 w-56 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg z-50">
+          <div className="py-1">
+            <button
+              onClick={handleCopySummary}
+              disabled={!fiveMinuteSummary}
+              className="w-full text-left px-4 py-2 text-sm text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            >
+              <Copy className="w-4 h-4" />
+              Copy Summary
+            </button>
+            <button
+              onClick={handleCopyFullDocument}
+              className="w-full text-left px-4 py-2 text-sm text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
+            >
+              <Copy className="w-4 h-4" />
+              Copy Full Document
+            </button>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="absolute right-0 mt-2 w-64 p-2 bg-red-100 dark:bg-red-900/30 border border-red-300 dark:border-red-700 text-red-700 dark:text-red-300 rounded text-xs">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -136,6 +136,16 @@ export const listMinimalPapers = async (): Promise<MinimalPaperItem[]> => {
     return response.json();
 }
 
+export const fetchPaperMarkdown = async (paperUuid: string): Promise<string> => {
+    const response = await fetch(`${API_URL}/papers/${paperUuid}/markdown`);
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`HTTP error! status: ${response.status}, message: ${errorText}`);
+    }
+    const data = await response.json();
+    return data.final_markdown;
+}
+
 // --- Public: check paper existence by arXiv ID ---
 export type CheckArxivResponse = {
     exists: boolean;

--- a/frontend/types/paper.ts
+++ b/frontend/types/paper.ts
@@ -43,6 +43,7 @@ export interface Paper {
   arxiv_url?: string | null;
   thumbnail_data_url?: string | null;
   five_minute_summary?: string | null;
+  final_markdown?: string | null;
   sections: Section[];
   tables: Table[];
   figures: Figure[];

--- a/papers/client.py
+++ b/papers/client.py
@@ -304,6 +304,7 @@ def save_paper(db: Session, processed_content: ProcessedDocument) -> Paper:
         "authors": processed_content.authors,
         "thumbnail_data_url": None,  # Will be set from first page
         "five_minute_summary": processed_content.five_minute_summary,
+        "final_markdown": processed_content.final_markdown,  # Original OCR markdown
         "sections": [],
         "tables": [],
         "figures": [],


### PR DESCRIPTION
- add airflow/dags/backfill_final_markdown_dag.py: one-time DAG to populate final_markdown field for papers processed before field was added
- add api/endpoints/paper_processing_endpoints.py: new /papers/{uuid}/markdown endpoint to retrieve original OCR markdown
- add frontend/components/CopyMarkdownButton.tsx: dropdown button component to copy paper summary or full document markdown to clipboard
- update frontend/app/paper/[slug]/page.tsx: integrate CopyMarkdownButton in paper detail view
- update frontend/services/api.ts: add fetchPaperMarkdown function to call new markdown endpoint
- update frontend/types/paper.ts: add final_markdown field to Paper type
- update papers/client.py: include final_markdown field when saving processed papers