### PR TITLE
Remove storage of full-page images and normalize bounding boxes

### DIFF
--- a/airflow/dags/cleanup_page_images_dag.py
+++ b/airflow/dags/cleanup_page_images_dag.py
@@ -1,0 +1,327 @@
+"""
+DAG to clean up page images from existing papers in the database.
+
+This DAG removes page image_data_url from the pages array in processed_content
+and normalizes bounding box coordinates to 0-1 range for all existing papers.
+
+Storage savings: ~300-400KB per paper by removing page images.
+"""
+
+import sys
+import pendulum
+import json
+from datetime import datetime
+from contextlib import contextmanager
+from typing import List, Dict, Any, Tuple
+
+from airflow.decorators import dag, task
+from sqlalchemy.orm import Session, undefer
+
+# Add project root to Python path
+sys.path.insert(0, '/opt/airflow')
+
+from shared.db import SessionLocal
+from papers.db.models import PaperRecord
+
+
+### CONSTANTS ###
+
+BATCH_SIZE = 10  # Process 10 papers per batch
+
+
+### DATABASE HELPERS ###
+
+@contextmanager
+def database_session():
+    """
+    Create a database session with automatic commit/rollback handling.
+
+    Yields:
+        Session: SQLAlchemy session for database operations
+
+    Raises:
+        Exception: Any database error that occurs during the transaction
+    """
+    session: Session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def get_papers_batch(session: Session, offset: int, limit: int) -> List[PaperRecord]:
+    """
+    Fetch a batch of completed papers with processed_content loaded.
+
+    Args:
+        session: Database session
+        offset: Number of records to skip
+        limit: Maximum number of records to return
+
+    Returns:
+        List[PaperRecord]: Batch of paper records with processed_content
+    """
+    return (
+        session.query(PaperRecord)
+        .filter(PaperRecord.status == 'completed')
+        .filter(PaperRecord.processed_content.isnot(None))
+        .options(undefer(PaperRecord.processed_content))
+        .order_by(PaperRecord.created_at.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+
+
+def normalize_bounding_box(bbox: List[int], page_width: int, page_height: int) -> List[float]:
+    """
+    Normalize bounding box coordinates to 0-1 range.
+
+    Args:
+        bbox: [x1, y1, x2, y2] in pixel coordinates
+        page_width: Page width in pixels
+        page_height: Page height in pixels
+
+    Returns:
+        List[float]: Normalized coordinates [x1, y1, x2, y2] in 0-1 range
+    """
+    if len(bbox) != 4:
+        return bbox
+
+    return [
+        bbox[0] / page_width,
+        bbox[1] / page_height,
+        bbox[2] / page_width,
+        bbox[3] / page_height
+    ]
+
+
+def cleanup_paper_images(paper_json: Dict[str, Any]) -> Tuple[Dict[str, Any], int, int]:
+    """
+    Remove page images and normalize bounding boxes in paper JSON.
+
+    Args:
+        paper_json: Parsed processed_content JSON
+
+    Returns:
+        tuple: (modified_json, bytes_saved, pages_cleaned)
+    """
+    bytes_saved = 0
+    pages_cleaned = 0
+
+    # Get page dimensions before removing images
+    page_dimensions = {}
+    for page in paper_json.get('pages', []):
+        page_num = page.get('page_number')
+        if page_num:
+            # Estimate page dimensions from image or use defaults
+            # Most PDFs are ~1080px wide when rendered
+            page_dimensions[page_num] = {
+                'width': 1080,
+                'height': 1400
+            }
+
+    # Clean up pages array - remove image_data_url
+    for page in paper_json.get('pages', []):
+        if 'image_data_url' in page:
+            # Calculate bytes saved (base64 encoded data)
+            image_data = page['image_data_url']
+            if isinstance(image_data, str):
+                bytes_saved += len(image_data)
+
+            # Remove the image data
+            page['image_data_url'] = None
+            pages_cleaned += 1
+
+    # Normalize bounding boxes in figures
+    for figure in paper_json.get('figures', []):
+        if 'bounding_box' in figure and 'page_image_size' in figure:
+            page_size = figure['page_image_size']
+            if len(page_size) == 2:
+                page_width, page_height = page_size
+                old_bbox = figure['bounding_box']
+
+                # Normalize the bounding box
+                figure['bounding_box'] = normalize_bounding_box(
+                    old_bbox, page_width, page_height
+                )
+
+                # Remove page_image_size as it's no longer needed
+                del figure['page_image_size']
+
+        # Remove obsolete fields
+        if 'image_path' in figure:
+            del figure['image_path']
+
+    # Normalize bounding boxes in tables
+    for table in paper_json.get('tables', []):
+        if 'bounding_box' in table and 'page_image_size' in table:
+            page_size = table['page_image_size']
+            if len(page_size) == 2:
+                page_width, page_height = page_size
+                old_bbox = table['bounding_box']
+
+                # Normalize the bounding box
+                table['bounding_box'] = normalize_bounding_box(
+                    old_bbox, page_width, page_height
+                )
+
+                # Remove page_image_size as it's no longer needed
+                del table['page_image_size']
+
+        # Remove obsolete fields
+        if 'image_path' in table:
+            del table['image_path']
+
+    return paper_json, bytes_saved, pages_cleaned
+
+
+### AIRFLOW TASKS ###
+
+@task
+def get_batch_numbers() -> List[int]:
+    """
+    Get list of batch numbers to process based on total papers count.
+
+    Returns:
+        List[int]: List of batch numbers (0-indexed)
+    """
+    with database_session() as session:
+        count = (
+            session.query(PaperRecord)
+            .filter(PaperRecord.status == 'completed')
+            .filter(PaperRecord.processed_content.isnot(None))
+            .count()
+        )
+
+    num_batches = (count // BATCH_SIZE) + (1 if count % BATCH_SIZE > 0 else 0)
+    batch_numbers = list(range(num_batches))
+
+    print(f"📊 Total papers to clean: {count}")
+    print(f"📦 Number of batches: {num_batches}")
+
+    return batch_numbers
+
+
+@task
+def process_batch(batch_num: int) -> Dict[str, Any]:
+    """
+    Process a single batch of papers to remove page images and normalize bboxes.
+
+    Args:
+        batch_num: Batch number (0-indexed)
+
+    Returns:
+        Dict containing batch statistics
+    """
+    offset = batch_num * BATCH_SIZE
+
+    with database_session() as session:
+        papers = get_papers_batch(session, offset, BATCH_SIZE)
+
+        if not papers:
+            print(f"✅ Batch {batch_num}: No papers found")
+            return {
+                'batch_num': batch_num,
+                'papers_processed': 0,
+                'bytes_saved': 0,
+                'pages_cleaned': 0
+            }
+
+        total_bytes_saved = 0
+        total_pages_cleaned = 0
+        papers_processed = 0
+
+        for paper in papers:
+            try:
+                # Parse the processed_content JSON
+                paper_json = json.loads(paper.processed_content)
+
+                # Clean up images and normalize bboxes
+                modified_json, bytes_saved, pages_cleaned = cleanup_paper_images(paper_json)
+
+                # Save back to database
+                paper.processed_content = json.dumps(modified_json, ensure_ascii=False)
+
+                total_bytes_saved += bytes_saved
+                total_pages_cleaned += pages_cleaned
+                papers_processed += 1
+
+            except Exception as e:
+                print(f"❌ Error processing paper {paper.paper_uuid}: {e}")
+                continue
+
+        session.commit()
+
+        result = {
+            'batch_num': batch_num,
+            'papers_processed': papers_processed,
+            'bytes_saved': total_bytes_saved,
+            'pages_cleaned': total_pages_cleaned
+        }
+
+        print(f"✅ Batch {batch_num}: Processed {papers_processed} papers, "
+              f"saved {total_bytes_saved / 1024 / 1024:.2f} MB, "
+              f"cleaned {total_pages_cleaned} pages")
+
+        return result
+
+
+@task
+def summarize_results(batch_results: List[Dict[str, Any]]) -> None:
+    """
+    Print summary of all batch processing results.
+
+    Args:
+        batch_results: List of batch result dictionaries
+    """
+    total_papers = sum(r['papers_processed'] for r in batch_results)
+    total_bytes = sum(r['bytes_saved'] for r in batch_results)
+    total_pages = sum(r['pages_cleaned'] for r in batch_results)
+
+    print("\n" + "="*60)
+    print("🎉 PAGE IMAGE CLEANUP COMPLETE")
+    print("="*60)
+    print(f"📄 Total papers processed: {total_papers}")
+    print(f"🗑️  Total pages cleaned: {total_pages}")
+    print(f"💾 Total storage saved: {total_bytes / 1024 / 1024:.2f} MB")
+    print(f"📦 Average per paper: {(total_bytes / total_papers / 1024) if total_papers > 0 else 0:.2f} KB")
+    print("="*60 + "\n")
+
+
+### DAG DEFINITION ###
+
+@dag(
+    dag_id='cleanup_page_images',
+    start_date=pendulum.datetime(2025, 1, 1, tz='UTC'),
+    schedule=None,  # Manual trigger only
+    catchup=False,
+    tags=['maintenance', 'cleanup', 'storage'],
+    description='Remove page images and normalize bounding boxes for existing papers',
+)
+def cleanup_page_images_workflow():
+    """
+    Main workflow to clean up page images from all existing papers.
+
+    Steps:
+    1. Get list of batch numbers to process
+    2. Process papers in batches (remove images, normalize bboxes)
+    3. Summarize results
+    """
+
+    # Get batch numbers
+    batch_numbers = get_batch_numbers()
+
+    # Process all batches using task mapping
+    batch_results = process_batch.expand(batch_num=batch_numbers)
+
+    # Summarize
+    summarize_results(batch_results)
+
+
+# Instantiate the DAG
+cleanup_page_images_dag = cleanup_page_images_workflow()

--- a/api/types/paper_processing_api_models.py
+++ b/api/types/paper_processing_api_models.py
@@ -2,28 +2,26 @@ from typing import List, Optional, Dict
 from pydantic import BaseModel
 
 class Page(BaseModel):
+    """Deprecated: Page images are no longer stored"""
     page_number: int
-    image_data_url: str
+    image_data_url: Optional[str] = None  # No longer stored
 
 class Figure(BaseModel):
     figure_identifier: str
+    short_id: Optional[str] = None
     location_page: int
     explanation: str
-    image_path: str
     image_data_url: str
     referenced_on_pages: List[int]
-    bounding_box: List[int]
-    page_image_size: List[int]
+    bounding_box: List[float]  # Normalized coordinates (0-1)
 
 class Table(BaseModel):
     table_identifier: str
     location_page: int
     explanation: str
-    image_path: str
     image_data_url: str
     referenced_on_pages: List[int]
-    bounding_box: List[int]
-    page_image_size: List[int]
+    bounding_box: List[float]  # Normalized coordinates (0-1)
 
 class Section(BaseModel):
     level: int

--- a/frontend/app/paper/[slug]/page.tsx
+++ b/frontend/app/paper/[slug]/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { Paper, Section, Figure, Table, type MinimalPaperItem } from '../../../types/paper';
-import { listMinimalPapers } from '../../../services/api';
-import { authClient } from '../../../services/auth';
-import { isPaperInUserList } from '../../../services/users';
+import { Paper } from '../../../types/paper';
 import AddToListButton from '../../../components/AddToListButton';
 import CopyMarkdownButton from '../../../components/CopyMarkdownButton';
 import { Loader, ExternalLink } from 'lucide-react';
@@ -13,7 +10,6 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
-import React from 'react';
 
 // Minimal approach: convert backticked segments that look like TeX into $...$
 const preprocessBacktickedMath = (src: string): string => {
@@ -21,59 +17,11 @@ const preprocessBacktickedMath = (src: string): string => {
   return (src || '').replace(/`([^`]+)`/g, (m, inner) => (looksMath(inner) ? `$${inner}$` : m));
 };
 
-export default function LayoutTestsPage() {
+export default function PaperPage() {
   const params = useParams<{ slug: string }>();
   const [paperData, setPaperData] = useState<Paper | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [error, setError] = useState<string | null>(null);
-  const { data: session } = authClient.useSession();
-  const [isInList, setIsInList] = useState<boolean>(false);
-  const [checkInListPending, setCheckInListPending] = useState<boolean>(false);
-  
-  const [availableFiles, setAvailableFiles] = useState<string[]>([]);
-  const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [similarItems, setSimilarItems] = useState<Array<{ key: string; title: string | null; authors: string | null; thumbnail_url: string | null; slug: string | null }>>([]);
-  const abortRef = useRef<AbortController | null>(null);
-  const mainRef = useRef<HTMLDivElement | null>(null);
-  const summaryRef = useRef<HTMLDivElement | null>(null);
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-  const [modalData, setModalData] = useState<
-    | { kind: 'figure'; data: Figure }
-    | { kind: 'table'; data: Table }
-    | null
-  >(null);
-  const pageImageContainerRef = useRef<HTMLDivElement | null>(null);
-  const pageImageRef = useRef<HTMLImageElement | null>(null);
-  const [modalZoom, setModalZoom] = useState<number>(1);
-
-  const fetchIndexAndMaybeData = async (explicitFile?: string | null) => {
-    try {
-      setIsLoading(true);
-      setError(null);
-      abortRef.current?.abort();
-      const controller = new AbortController();
-      abortRef.current = controller;
-      const indexRes = await fetch('/layouttests/data', { signal: controller.signal, cache: 'no-store' });
-      if (!indexRes.ok) throw new Error(`Failed to list preloaded papers: ${indexRes.status}`);
-      const indexJson = await indexRes.json();
-      const files: string[] = Array.isArray(indexJson?.files) ? indexJson.files : [];
-      setAvailableFiles(files);
-      const fileToLoad = explicitFile ?? selectedFile ?? files[0] ?? null;
-      if (!fileToLoad) throw new Error('No papers found in data/paperjsons/');
-      setSelectedFile(fileToLoad);
-      const response = await fetch(`/layouttests/data?file=${encodeURIComponent(fileToLoad)}`, { signal: controller.signal, cache: 'no-store' });
-      if (!response.ok) {
-        throw new Error(`Failed to load JSON: ${response.status} ${response.statusText}`);
-      }
-      const data: Paper = await response.json();
-      setPaperData(data);
-    } catch (err) {
-      if ((err as any)?.name === 'AbortError') return;
-      setError(err instanceof Error ? err.message : 'Unknown error loading JSON');
-    } finally {
-      setIsLoading(false);
-    }
-  };
 
   useEffect(() => {
     const slug = params?.slug || '';
@@ -98,174 +46,48 @@ export default function LayoutTestsPage() {
         }
         const uuid: string | undefined = json?.paper_uuid;
         if (!uuid) throw new Error('Paper not found');
-        if (!cancelled) {
-          setIsLoading(true);
-          await fetchIndexAndMaybeData(`${uuid}.json`);
-          setIsLoading(false);
-        }
-      } catch (e: any) {
-        if (!cancelled) setError(e instanceof Error ? e.message : 'Unknown error');
-      }
-    })();
-    return () => {
-      abortRef.current?.abort();
-      cancelled = true;
-    };
-  }, [params]);
 
-  // Log paper id instead of displaying it
-  useEffect(() => {
-    if (paperData?.paper_id) {
-      try { console.log('[paper] id', paperData.paper_id); } catch {}
-    }
-  }, [paperData?.paper_id]);
+        setIsLoading(true);
+        // Fetch paper data using summary endpoint (lightweight, no page images)
+        const paperRes = await fetch(`/api/papers/${uuid}/summary`, { cache: 'no-store' });
+        if (!paperRes.ok) throw new Error(`Failed to load paper: ${paperRes.status}`);
+        const paperJson = await paperRes.json();
+        if (cancelled) return;
 
-  // If logged in and paper is loaded, check if it's already in user's list
-  useEffect(() => {
-    const run = async () => {
-      if (!session?.user?.id || !paperData?.paper_id) return;
-      try {
-        setCheckInListPending(true);
-        const exists = await isPaperInUserList(paperData.paper_id, session.user.id);
-        setIsInList(Boolean(exists));
-      } catch {
-        // ignore
-      } finally {
-        setCheckInListPending(false);
-      }
-    };
-    run();
-  }, [session?.user?.id, paperData?.paper_id]);
-
-  
-
-  // Load metadata for similar papers (title/authors/thumbnail) via minimal endpoint
-  useEffect(() => {
-    const others = availableFiles.filter((f) => f !== (selectedFile ?? ''));
-    if (others.length === 0) {
-      setSimilarItems([]);
-      return;
-    }
-    (async () => {
-      try {
-        const all: MinimalPaperItem[] = await listMinimalPapers();
-        const othersByUuid = new Set(others.map((n) => n.replace(/\.json$/i, '')));
-        const results = all
-          .filter((it) => othersByUuid.has(it.paper_uuid))
-          .map((it) => ({ key: it.paper_uuid, title: it.title, authors: it.authors, thumbnail_url: it.thumbnail_url, slug: it.slug }));
-        setSimilarItems(results);
-      } catch {
-        setSimilarItems([]);
-      }
-    })();
-  }, [availableFiles, selectedFile]);
-
-
-
-  // Note: processInlineImages function removed - backend now generates proper markdown images
-  // Images now come as: ![Figure shortid](shortid:weu33j4l)
-  // Future: Backend can add descriptions like: ![Figure shortid](shortid:weu33j4l "Custom description")
-
-
-  useEffect(() => {
-    if (!isModalOpen || !paperData || !modalData) return;
-    const pageNum = modalData.data.location_page;
-    const rawBbox: any = (modalData.data as any).bounding_box;
-    const bbox: [number, number, number, number] =
-      Array.isArray(rawBbox) && rawBbox.length === 4 && rawBbox.every((n: any) => typeof n === 'number')
-        ? (rawBbox as [number, number, number, number])
-        : [0, 0, 0, 0];
-    try {
-      console.log('[modal] effect init', {
-        pageNum,
-        bbox,
-        pagesCount: paperData.pages?.length ?? 0,
-      });
-    } catch {}
-    // After image loads, scroll container to center bbox
-    const imgEl = pageImageRef.current;
-    const container = pageImageContainerRef.current;
-    if (!imgEl || !container) return;
-    const onLoad = () => {
-      const [x1, y1, x2, y2] = bbox;
-      const bboxW = Math.max(1, x2 - x1);
-      const bboxH = Math.max(1, y2 - y1);
-      const hasValidBbox = (x2 > x1) && (y2 > y1);
-      if (!hasValidBbox) {
-        console.warn('[modal] invalid or empty bbox, skipping auto-zoom', { x1, y1, x2, y2 });
-        setModalZoom(1);
-        return;
-      }
-      // Compute zoom so bbox fits within ~70% of container
-      const targetW = container.clientWidth * 0.7;
-      const targetH = container.clientHeight * 0.7;
-      const scale = Math.max(1, Math.min(targetW / bboxW, targetH / bboxH));
-      setModalZoom(scale);
-      const centerX = (x1 + x2) / 2 * scale;
-      const centerY = (y1 + y2) / 2 * scale;
-      try {
-        console.log('[modal] image onLoad', {
-          imgComplete: imgEl.complete,
-          containerSize: { w: container.clientWidth, h: container.clientHeight },
-          bbox: { x1, y1, x2, y2, w: bboxW, h: bboxH },
-          scale,
-          scrollTarget: { left: Math.max(0, centerX - container.clientWidth / 2), top: Math.max(0, centerY - container.clientHeight / 2) },
+        setPaperData({
+          paper_id: paperJson.paper_id,
+          title: paperJson.title,
+          authors: paperJson.authors,
+          arxiv_url: paperJson.arxiv_url,
+          five_minute_summary: paperJson.five_minute_summary,
+          thumbnail_url: paperJson.thumbnail_url,
         });
-      } catch {}
-      container.scrollTo({
-        left: Math.max(0, centerX - container.clientWidth / 2),
-        top: Math.max(0, centerY - container.clientHeight / 2),
-        behavior: 'smooth',
-      });
-    };
-    try {
-      console.log('[modal] before load handler', {
-        imgComplete: imgEl.complete,
-        naturalSize: { w: (imgEl as any).naturalWidth, h: (imgEl as any).naturalHeight },
-        containerSize: { w: container.clientWidth, h: container.clientHeight },
-      });
-    } catch {}
-    if (imgEl.complete) onLoad();
-    else imgEl.addEventListener('load', onLoad, { once: true });
-    return () => imgEl.removeEventListener('load', onLoad as any);
-  }, [isModalOpen, modalData, paperData]);
+      } catch (err) {
+        console.error('Error loading paper:', err);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [params?.slug]);
 
-  const openAssetModal = (payload: { kind: 'figure'; data: Figure } | { kind: 'table'; data: Table }) => {
-    try {
-      console.log('[modal] open', {
-        kind: payload.kind,
-        id:
-          payload.kind === 'figure'
-            ? (payload.data as Figure).figure_identifier
-            : (payload.data as Table).table_identifier,
-        page: payload.data.location_page,
-        bbox: (payload.data as any)?.bounding_box,
-        pageImageSize: (payload.data as any)?.page_image_size,
-      });
-    } catch (e) {
-      console.warn('[modal] open log error', e);
-    }
-    setModalData(payload);
-    setIsModalOpen(true);
-  };
-  const closeModal = () => {
-    console.log('[modal] close');
-    setIsModalOpen(false);
-    setModalData(null);
-    setModalZoom(1);
-  };
+  useEffect(() => {
+    // Similar papers functionality disabled for now
+    if (!paperData) return;
+    setSimilarItems([]);
+  }, [paperData]);
 
   return (
     <div className="flex items-start gap-4 p-2 sm:p-4 min-h-0 text-gray-900 dark:text-gray-100">
       {/* Content - Now full width without sidebars */}
-      <main ref={mainRef} className="flex-1 max-w-4xl mx-auto w-full p-2 sm:p-4 flex flex-col">
+      <main className="flex-1 max-w-4xl mx-auto w-full p-2 sm:p-4 flex flex-col">
         {paperData ? (
           <>
             <div className="mb-4 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg shadow-md p-3 sm:p-4">
               <div className="flex flex-col sm:flex-row items-start gap-3 sm:gap-4 max-w-full">
-                {(paperData as any)?.thumbnail_url && (
+                {paperData.thumbnail_url && (
                   <img
-                    src={(paperData as any).thumbnail_url as string}
+                    src={paperData.thumbnail_url}
                     alt="Paper thumbnail"
                     className="w-20 h-20 sm:w-24 sm:h-24 rounded-md object-cover flex-shrink-0 mx-auto sm:mx-0"
                   />
@@ -292,14 +114,14 @@ export default function LayoutTestsPage() {
                     <AddToListButton paperId={paperData.paper_id} paperTitle={paperData.title || undefined} />
                     <CopyMarkdownButton paperUuid={paperData.paper_id} fiveMinuteSummary={paperData.five_minute_summary} />
                   </div>
-                  
+
                 </div>
               </div>
             </div>
 
             {/* 5-Minute Summary */}
             {paperData.five_minute_summary && (
-              <div ref={summaryRef} className="mb-6 sm:mb-8 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg shadow-md overflow-hidden">
+              <div className="mb-6 sm:mb-8 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg shadow-md overflow-hidden">
                 <div className="p-3 sm:p-4">
                   <div className="flex items-center gap-2 mb-3">
                     <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
@@ -322,7 +144,7 @@ export default function LayoutTestsPage() {
               </div>
             )}
 
-            {/* Similar Papers - Moved below summary */}
+            {/* Similar Papers */}
             {similarItems.length > 0 && (
               <div className="mb-6 sm:mb-8 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg shadow-md overflow-hidden">
                 <div className="p-3 sm:p-4">
@@ -364,83 +186,12 @@ export default function LayoutTestsPage() {
             <div className="flex items-center justify-center h-full text-gray-500 dark:text-gray-400">
               <div className="flex flex-col items-center">
                 <Loader className="animate-spin w-10 h-10 mb-3" />
-                <p>Loading JSON...</p>
+                <p>Loading paper...</p>
               </div>
             </div>
           ) : null
         )}
     </main>
-
-      {isModalOpen && paperData && modalData && (
-        <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-2 sm:p-4" onClick={closeModal}>
-          <div className="bg-white dark:bg-gray-900 w-full max-w-6xl h-[95vh] sm:h-[80vh] rounded-lg overflow-hidden shadow-xl" onClick={(e) => e.stopPropagation()}>
-            <div className="flex flex-col sm:flex-row h-full">
-              {/* Left: Full page image, scrollable, with bbox overlay */}
-              <div ref={pageImageContainerRef} className="flex-1 relative overflow-auto bg-gray-100 dark:bg-gray-800">
-                {(() => {
-                  const pageNum = modalData.data.location_page;
-                  const page = (paperData.pages || []).find((p) => p.page_number === pageNum);
-                  const [x1, y1, x2, y2] = Array.isArray((modalData.data as any).bounding_box)
-                    ? (modalData.data as any).bounding_box as [number, number, number, number]
-                    : [0, 0, 0, 0];
-                  const hasValidBbox = (x2 > x1) && (y2 > y1);
-                  try {
-                    console.log('[modal] render', {
-                      pageNum,
-                      hasPageImage: !!page?.image_data_url,
-                      bbox: { x1, y1, x2, y2 },
-                      modalZoom,
-                    });
-                  } catch {}
-                  if (!page?.image_data_url) {
-                    return (
-                      <div className="w-full h-full flex items-center justify-center text-sm text-gray-600 dark:text-gray-300">
-                        No page image available for page {pageNum}.
-                      </div>
-                    );
-                  }
-                  return (
-                    <div className="relative inline-block" style={{ transform: `scale(${modalZoom})`, transformOrigin: 'top left' }}>
-                      <img ref={pageImageRef} src={page.image_data_url} alt={`Page ${pageNum}`} className="block max-w-none" />
-                      {/* BBox overlay */}
-                      {hasValidBbox && (
-                        <div
-                          className="absolute border-2 border-blue-500/80 bg-blue-500/10 pointer-events-none"
-                          style={{ left: x1, top: y1, width: Math.max(0, x2 - x1), height: Math.max(0, y2 - y1) }}
-                        />
-                      )}
-                    </div>
-                  );
-                })()}
-              </div>
-              {/* Right: Explanation */}
-              <div className="w-full sm:w-[28rem] border-t sm:border-t-0 sm:border-l border-gray-200 dark:border-gray-700 p-4 flex flex-col max-h-[40vh] sm:max-h-none">
-                <div className="flex items-start justify-between mb-3">
-                  <div>
-                    <h3 className="text-lg font-semibold">
-                      {modalData.kind === 'figure' ? (modalData.data as Figure).figure_identifier : (modalData.data as Table).table_identifier}
-                    </h3>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">Page {modalData.data.location_page}</p>
-                  </div>
-                  <button onClick={closeModal} className="text-sm px-2 py-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800">Close</button>
-                </div>
-                <div className="flex-1 overflow-auto">
-                  <div className="prose dark:prose-invert max-w-none text-sm">
-                    <ReactMarkdown
-                      remarkPlugins={[remarkGfm, remarkMath]}
-                      rehypePlugins={[[rehypeKatex, { strict: false, throwOnError: false }]]}
-                    >
-                      {preprocessBacktickedMath(modalData.data.explanation || '')}
-                    </ReactMarkdown>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }
-
-

--- a/frontend/types/paper.ts
+++ b/frontend/types/paper.ts
@@ -3,27 +3,24 @@ export interface Figure {
   short_id?: string;
   location_page: number;
   explanation: string;
-  image_path: string;
   image_data_url: string;
   referenced_on_pages: number[];
-  bounding_box: [number, number, number, number];
-  page_image_size: [number, number];
+  bounding_box: [number, number, number, number];  // Normalized coordinates (0-1)
 }
 
 export interface Page {
+  /** Deprecated: Page images are no longer stored */
   page_number: number;
-  image_data_url: string;
+  image_data_url?: string;
 }
 
 export interface Table {
   table_identifier: string;
   location_page: number;
   explanation: string;
-  image_path: string;
   image_data_url: string;
   referenced_on_pages: number[];
-  bounding_box: [number, number, number, number];
-  page_image_size: [number, number];
+  bounding_box: [number, number, number, number];  // Normalized coordinates (0-1)
 }
 
 export interface Section {
@@ -42,12 +39,13 @@ export interface Paper {
   authors?: string | null;
   arxiv_url?: string | null;
   thumbnail_data_url?: string | null;
+  thumbnail_url?: string | null;  // From summary endpoint
   five_minute_summary?: string | null;
   final_markdown?: string | null;
-  sections: Section[];
-  tables: Table[];
-  figures: Figure[];
-  pages: Page[];
+  sections?: Section[];
+  tables?: Table[];
+  figures?: Figure[];
+  pages?: Page[];
   usage_summary?: {
     currency: 'USD';
     total_cost: number;


### PR DESCRIPTION
- add airflow/dags/cleanup_page_images_dag.py: DAG to remove page images from existing papers and normalize bounding boxes to 0-1 range
- update api/types/paper_processing_api_models.py: deprecate page image storage, normalize bounding box coordinates to 0-1 range, remove obsolete image_path and page_image_size fields
- update frontend/app/paper/[slug]/page.tsx: remove page image modal and zoom functionality, switch to lightweight summary API endpoint
- update frontend/types/paper.ts: remove image_path and page_image_size fields, change bounding box to normalized float coordinates
- update papers/client.py: remove page image storage from processing pipeline, normalize bounding boxes on extraction