### PR TITLE
Add infinite scroll papers feed with expandable summaries

### DIFF
--- a/api/endpoints/paper_processing_endpoints.py
+++ b/api/endpoints/paper_processing_endpoints.py
@@ -3,7 +3,7 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from typing import Union, List, Optional, Dict, Any
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
-from api.types.paper_processing_api_models import Paper, JobStatusResponse, MinimalPaperItem
+from api.types.paper_processing_api_models import Paper, JobStatusResponse, MinimalPaperItem, PaginatedMinimalPapers
 from api.types.paper_processing_endpoints import JobDbStatus
 from paperprocessor.client import process_paper_pdf
 from papers.client import build_paper_slug
@@ -214,14 +214,23 @@ async def enqueue_arxiv(req: EnqueueArxivRequest, db: Session = Depends(get_sess
 
 
  
-@router.get("/papers/minimal", response_model=List[MinimalPaperItem])
-def list_minimal_papers(db: Session = Depends(get_session)):
+@router.get("/papers/minimal")
+def list_minimal_papers(
+    page: Optional[int] = None,
+    limit: Optional[int] = None,
+    db: Session = Depends(get_session)
+):
     """
     Returns a minimal list of papers: paper_uuid, title, authors, thumbnail_data_url, slug.
+    Supports optional pagination with page and limit query parameters.
+
+    If both page and limit are provided, returns paginated response.
+    Otherwise, returns legacy list format.
+
     Delegates to papers.client.list_minimal_papers.
     """
-    items = papers_client.list_minimal_papers(db)
-    return items
+    result = papers_client.list_minimal_papers(db, page=page, limit=limit)
+    return result
 
 
 

--- a/api/types/paper_processing_api_models.py
+++ b/api/types/paper_processing_api_models.py
@@ -71,3 +71,10 @@ class MinimalPaperItem(BaseModel):
     authors: Optional[str] = None
     thumbnail_url: Optional[str] = None
     slug: Optional[str] = None
+
+
+class PaginatedMinimalPapers(BaseModel):
+    items: List[MinimalPaperItem]
+    total: int
+    page: int
+    has_more: bool

--- a/frontend/app/scrollingpapers/page.tsx
+++ b/frontend/app/scrollingpapers/page.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import React, { useEffect, useState, useRef, useCallback, useLayoutEffect } from 'react';
+import type { MinimalPaperItem, Paper } from '../../types/paper';
+import { listMinimalPapersPaginated, fetchPaperSummary } from '../../services/api';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
+
+const ITEMS_PER_PAGE = 20;
+
+// Preprocess backticked math expressions
+const preprocessBacktickedMath = (src: string): string => {
+  const looksMath = (s: string) => /[{}_^\\]|\\[a-zA-Z]+/.test(s);
+  return (src || '').replace(/`([^`]+)`/g, (m, inner) => (looksMath(inner) ? `$${inner}$` : m));
+};
+
+export default function ScrollingPapersPage() {
+  const [papers, setPapers] = useState<MinimalPaperItem[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [hasMore, setHasMore] = useState<boolean>(true);
+  const [expandedPaperIds, setExpandedPaperIds] = useState<Set<string>>(new Set());
+  const [paperSummaries, setPaperSummaries] = useState<Map<string, Paper>>(new Map());
+  const [loadingSummaries, setLoadingSummaries] = useState<Set<string>>(new Set());
+  const [pendingScrollAdjustment, setPendingScrollAdjustment] = useState<{ elementId: string; offsetFromTop: number } | null>(null);
+
+  const observerTarget = useRef<HTMLDivElement>(null);
+
+  // Load papers from a specific page
+  const loadPage = useCallback(async (page: number) => {
+    if (isLoading) return;
+
+    try {
+      setIsLoading(true);
+      setError(null);
+      const result = await listMinimalPapersPaginated(page, ITEMS_PER_PAGE);
+
+      setPapers(prev => {
+        // Avoid duplicates
+        const existingIds = new Set(prev.map(p => p.paper_uuid));
+        const newPapers = result.items.filter(p => !existingIds.has(p.paper_uuid));
+
+        // Load summaries for new papers
+        newPapers.forEach(paper => {
+          if (!paperSummaries.has(paper.paper_uuid) && !loadingSummaries.has(paper.paper_uuid)) {
+            loadPaperSummary(paper.paper_uuid);
+          }
+        });
+
+        return [...prev, ...newPapers];
+      });
+
+      setHasMore(result.has_more);
+      setCurrentPage(page);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isLoading, paperSummaries, loadingSummaries]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Load initial page
+  useEffect(() => {
+    loadPage(1);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Infinite scroll observer
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries[0].isIntersecting && hasMore && !isLoading) {
+          loadPage(currentPage + 1);
+        }
+      },
+      { threshold: 1.0 }
+    );
+
+    const currentTarget = observerTarget.current;
+    if (currentTarget) {
+      observer.observe(currentTarget);
+    }
+
+    return () => {
+      if (currentTarget) {
+        observer.unobserve(currentTarget);
+      }
+    };
+  }, [hasMore, isLoading, currentPage, loadPage]);
+
+  // Restore scroll position after DOM update
+  useLayoutEffect(() => {
+    if (pendingScrollAdjustment) {
+      const element = document.getElementById(pendingScrollAdjustment.elementId);
+      if (element) {
+        const currentOffsetFromTop = element.getBoundingClientRect().top;
+        const scrollAdjustment = currentOffsetFromTop - pendingScrollAdjustment.offsetFromTop;
+        window.scrollBy(0, scrollAdjustment);
+      }
+      setPendingScrollAdjustment(null);
+    }
+  }, [pendingScrollAdjustment]);
+
+  // Toggle paper expansion
+  const toggleExpanded = useCallback((paperUuid: string) => {
+    const isCurrentlyExpanded = expandedPaperIds.has(paperUuid);
+
+    if (isCurrentlyExpanded) {
+      // Just collapse this one
+      setExpandedPaperIds(prev => {
+        const next = new Set(prev);
+        next.delete(paperUuid);
+        return next;
+      });
+    } else {
+      // Expanding a new one - need to handle scroll preservation
+      const previouslyExpanded = Array.from(expandedPaperIds)[0];
+
+      if (previouslyExpanded) {
+        // Measure the clicked element's position before state change
+        const clickedElement = document.getElementById(`paper-${paperUuid}`);
+        if (clickedElement) {
+          const offsetFromTop = clickedElement.getBoundingClientRect().top;
+          setPendingScrollAdjustment({ elementId: `paper-${paperUuid}`, offsetFromTop });
+        }
+      }
+
+      // Collapse previous and expand new one
+      setExpandedPaperIds(new Set([paperUuid]));
+
+      // Load summary if not already loaded
+      if (!paperSummaries.has(paperUuid) && !loadingSummaries.has(paperUuid)) {
+        loadPaperSummary(paperUuid);
+      }
+    }
+  }, [expandedPaperIds, paperSummaries, loadingSummaries]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Load paper summary
+  const loadPaperSummary = async (paperUuid: string) => {
+    setLoadingSummaries(prev => new Set(prev).add(paperUuid));
+
+    try {
+      const summary = await fetchPaperSummary(paperUuid);
+      setPaperSummaries(prev => new Map(prev).set(paperUuid, summary));
+    } catch (e) {
+      console.error('Failed to load summary:', e);
+    } finally {
+      setLoadingSummaries(prev => {
+        const next = new Set(prev);
+        next.delete(paperUuid);
+        return next;
+      });
+    }
+  };
+
+  return (
+    <main className="w-full">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        <div className="mb-4">
+          <h1 className="text-3xl font-bold">Papers Feed</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
+            Scroll through papers and click to expand summaries
+          </p>
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 rounded-md border border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/40 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        <div className="space-y-4">
+          {papers.map((paper) => {
+            const isExpanded = expandedPaperIds.has(paper.paper_uuid);
+            const summary = paperSummaries.get(paper.paper_uuid);
+            const isLoadingSummary = loadingSummaries.has(paper.paper_uuid);
+
+            return (
+              <div
+                key={paper.paper_uuid}
+                id={`paper-${paper.paper_uuid}`}
+                className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden shadow-sm transition-all"
+              >
+                {/* Title and Authors */}
+                <div className="p-4 pb-3">
+                  <h2 className="font-semibold text-lg text-gray-900 dark:text-gray-100 line-clamp-3">
+                    {paper.title || 'Untitled'}
+                  </h2>
+                  {paper.authors && (
+                    <p className="text-sm text-gray-600 dark:text-gray-400 mt-2 line-clamp-2">
+                      {paper.authors}
+                    </p>
+                  )}
+                </div>
+
+                {/* Thumbnail - always clickable */}
+                <button
+                  onClick={() => toggleExpanded(paper.paper_uuid)}
+                  className="w-full text-left"
+                >
+                  <div className="w-full aspect-square bg-gray-100 dark:bg-gray-700 overflow-hidden hover:opacity-95 transition-opacity">
+                    {paper.thumbnail_url ? (
+                      <img
+                        src={paper.thumbnail_url}
+                        alt=""
+                        className="w-full h-full object-cover object-top"
+                      />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center text-gray-400 text-sm">
+                        No thumbnail
+                      </div>
+                    )}
+                  </div>
+                </button>
+
+                {/* Summary Preview or Expanded Content */}
+                {isLoadingSummary ? (
+                  <div className="border-t border-gray-200 dark:border-gray-700 px-4 py-3">
+                    <div className="text-gray-600 dark:text-gray-400 text-sm">
+                      Loading summary...
+                    </div>
+                  </div>
+                ) : summary?.five_minute_summary ? (
+                  isExpanded ? (
+                    // Fully expanded
+                    <div className="border-t border-gray-200 dark:border-gray-700 p-4 bg-gray-50 dark:bg-gray-900/50">
+                      <div className="mb-3">
+                        <span className="inline-block px-2 py-0.5 text-xs font-medium rounded bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300">
+                          5-Minute Summary
+                        </span>
+                      </div>
+                      <div className="prose prose-sm dark:prose-invert max-w-none">
+                        <ReactMarkdown
+                          remarkPlugins={[remarkGfm, remarkMath]}
+                          rehypePlugins={[rehypeKatex]}
+                        >
+                          {preprocessBacktickedMath(summary.five_minute_summary)}
+                        </ReactMarkdown>
+                      </div>
+                      <button
+                        onClick={() => toggleExpanded(paper.paper_uuid)}
+                        className="mt-4 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        Show less
+                      </button>
+                    </div>
+                  ) : (
+                    // Preview with fade-out
+                    <button
+                      onClick={() => toggleExpanded(paper.paper_uuid)}
+                      className="w-full text-left border-t border-gray-200 dark:border-gray-700 px-4 pb-4 pt-3 relative group"
+                    >
+                      <div className="relative overflow-hidden" style={{ maxHeight: '10rem' }}>
+                        <div className="prose prose-sm dark:prose-invert max-w-none text-gray-700 dark:text-gray-300">
+                          <ReactMarkdown
+                            remarkPlugins={[remarkGfm, remarkMath]}
+                            rehypePlugins={[rehypeKatex]}
+                          >
+                            {preprocessBacktickedMath(summary.five_minute_summary)}
+                          </ReactMarkdown>
+                        </div>
+                        {/* Fade overlay */}
+                        <div className="absolute bottom-0 left-0 right-0 h-20 bg-gradient-to-t from-white dark:from-gray-800 to-transparent pointer-events-none group-hover:from-gray-50 dark:group-hover:from-gray-750 transition-colors" />
+                      </div>
+                      <div className="mt-2 text-xs text-blue-600 dark:text-blue-400 group-hover:underline">
+                        Click to read more
+                      </div>
+                    </button>
+                  )
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Loading indicator */}
+        {isLoading && (
+          <div className="text-center py-8 text-gray-600 dark:text-gray-300">
+            Loading more papers...
+          </div>
+        )}
+
+        {/* Intersection observer target */}
+        {hasMore && !isLoading && (
+          <div ref={observerTarget} className="h-8" />
+        )}
+
+        {/* End of list */}
+        {!hasMore && papers.length > 0 && (
+          <div className="text-center py-8 text-gray-600 dark:text-gray-400 text-sm">
+            You've reached the end of the list
+          </div>
+        )}
+
+        {/* No papers */}
+        {!isLoading && papers.length === 0 && (
+          <div className="text-center py-8 text-gray-600 dark:text-gray-300">
+            No papers found
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/components/NavBar.tsx
+++ b/frontend/components/NavBar.tsx
@@ -43,6 +43,11 @@ export default function NavBar({ className = '' }: NavBarProps) {
               All Papers
             </Link>
           </li>
+          <li>
+            <Link href="/scrollingpapers" className="text-sm text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">
+              Papers Feed
+            </Link>
+          </li>
           {/*<li>
             <Link href="/donate" className="text-sm text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">
               Donate Inference
@@ -117,6 +122,13 @@ export default function NavBar({ className = '' }: NavBarProps) {
                 className="block py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
               >
                 All Papers
+              </Link>
+              <Link
+                href="/scrollingpapers"
+                onClick={closeMobileMenu}
+                className="block py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
+              >
+                Papers Feed
               </Link>
               <Link
                 href="https://github.com/ArthurDevel/papersummarizertool"

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -1,4 +1,4 @@
-import { JobStatusResponse, Paper, type MinimalPaperItem } from '../types/paper';
+import { JobStatusResponse, Paper, type MinimalPaperItem, type PaginatedMinimalPapers } from '../types/paper';
 
 export const API_URL = '/api'; // The backend is on port 8000, but we're proxying, see next.config.js for dev, and /api/[...slug] for prod.
 
@@ -136,6 +136,18 @@ export const listMinimalPapers = async (): Promise<MinimalPaperItem[]> => {
     return response.json();
 }
 
+export const listMinimalPapersPaginated = async (page: number, limit: number): Promise<PaginatedMinimalPapers> => {
+    const url = new URL(`${API_URL}/papers/minimal`, window.location.origin);
+    url.searchParams.set('page', page.toString());
+    url.searchParams.set('limit', limit.toString());
+    const response = await fetch(url.toString());
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`HTTP error! status: ${response.status}, message: ${errorText}`);
+    }
+    return response.json();
+}
+
 export const fetchPaperMarkdown = async (paperUuid: string): Promise<string> => {
     const response = await fetch(`${API_URL}/papers/${paperUuid}/markdown`);
     if (!response.ok) {
@@ -144,6 +156,15 @@ export const fetchPaperMarkdown = async (paperUuid: string): Promise<string> => 
     }
     const data = await response.json();
     return data.final_markdown;
+}
+
+export const fetchPaperSummary = async (paperUuid: string): Promise<Paper> => {
+    const response = await fetch(`${API_URL}/papers/${paperUuid}/summary`);
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`HTTP error! status: ${response.status}, message: ${errorText}`);
+    }
+    return response.json();
 }
 
 // --- Public: check paper existence by arXiv ID ---

--- a/frontend/types/paper.ts
+++ b/frontend/types/paper.ts
@@ -76,3 +76,10 @@ export interface MinimalPaperItem {
   thumbnail_url: string | null;
   slug: string | null;
 }
+
+export interface PaginatedMinimalPapers {
+  items: MinimalPaperItem[];
+  total: number;
+  page: number;
+  has_more: boolean;
+}

--- a/papers/db/client.py
+++ b/papers/db/client.py
@@ -87,12 +87,12 @@ def update_paper_record(db: Session, paper_uuid: str, paper_data) -> PaperRecord
     return record
 
 
-def list_paper_records(db: Session, statuses: Optional[List[str]], limit: int) -> List[PaperRecord]:
+def list_paper_records(db: Session, statuses: Optional[List[str]], limit: int, offset: int = 0) -> List[PaperRecord]:
     """List paper records from database (without heavy processed_content column)."""
     q = db.query(PaperRecord).options(defer(PaperRecord.processed_content))
     if statuses:
         q = q.filter(PaperRecord.status.in_(statuses))
-    q = q.order_by(PaperRecord.created_at.desc()).limit(max(1, min(limit, 1000)))
+    q = q.order_by(PaperRecord.created_at.desc()).limit(max(1, min(limit, 1000))).offset(offset)
     return q.all()
 
 


### PR DESCRIPTION
- add backend: pagination support to papers/minimal endpoint with page and limit query parameters
- add backend: PaginatedMinimalPapers response model for paginated responses
- update papers/client.py: modify list_minimal_papers to support optional pagination while maintaining backward compatibility
- update papers/db/client.py: add offset parameter to list_paper_records for pagination
- add frontend: /scrollingpapers page with infinite scroll using IntersectionObserver
- add frontend: expandable paper cards showing preview with fade-out effect
- add frontend: scroll position preservation when expanding/collapsing papers
- add frontend: auto-loading of paper summaries on scroll
- add frontend: markdown rendering support for summaries with math expressions
- add frontend/services/api.ts: listMinimalPapersPaginated and fetchPaperSummary functions
- add frontend/types/paper.ts: PaginatedMinimalPapers interface
- update NavBar: add Papers Feed link to navigation menu