### PR TITLE
Add Microsoft Research papers DAG with pagination support

### DIFF
--- a/airflow/dags/daily_microsoft_research_papers_dag.py
+++ b/airflow/dags/daily_microsoft_research_papers_dag.py
@@ -1,0 +1,507 @@
+import sys
+import os
+import pendulum
+import time
+import hashlib
+import requests
+from airflow.decorators import dag, task
+from typing import List, Dict, Any, Optional
+from contextlib import contextmanager
+from airflow.models import Param
+
+# Add project root to Python path to find shared modules
+sys.path.insert(0, '/opt/airflow')
+
+from sqlalchemy.orm import Session
+from shared.db import SessionLocal
+from papers.models import ExternalPopularitySignal
+from papers.client import create_paper
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.chrome.options import Options
+import re
+
+
+# ============================================================================
+# CONSTANTS
+# ============================================================================
+
+MICROSOFT_RESEARCH_URL = "https://www.microsoft.com/en-us/research/publications"
+
+
+# ============================================================================
+# HELPER FUNCTIONS
+# ============================================================================
+
+def setup_driver():
+    """
+    Set up Selenium Chrome driver with headless options.
+
+    Returns:
+        webdriver.Chrome: Configured Chrome WebDriver instance
+    """
+    from selenium.webdriver.chrome.service import Service
+
+    chrome_options = Options()
+    chrome_options.add_argument("--headless")
+    chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("--disable-dev-shm-usage")
+    chrome_options.add_argument("--disable-gpu")
+    chrome_options.add_argument("user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
+
+    # Point to system chromium binary
+    chrome_options.binary_location = "/usr/bin/chromium"
+
+    # Point to system chromedriver
+    service = Service(executable_path="/usr/bin/chromedriver")
+
+    driver = webdriver.Chrome(service=service, options=chrome_options)
+    return driver
+
+
+def extract_arxiv_id_from_url(url: str) -> Optional[str]:
+    """
+    Extract arXiv ID from URL.
+
+    Args:
+        url: URL that may contain an arXiv ID
+
+    Returns:
+        Optional[str]: Extracted arXiv ID or None if not found
+    """
+    arxiv_match = re.search(r'arxiv\.org/(?:abs|pdf)/(\d+\.\d+)', url, re.I)
+    if arxiv_match:
+        return arxiv_match.group(1)
+    return None
+
+
+def compute_pdf_hash(pdf_url: str) -> str:
+    """
+    Download PDF and compute its hash for uniqueness.
+    Raises an error if the PDF cannot be downloaded or is invalid.
+
+    Args:
+        pdf_url: URL of the PDF to download
+
+    Returns:
+        str: SHA256 hash of the PDF content
+
+    Raises:
+        ValueError: If the downloaded content is not a valid PDF
+        Exception: If download fails
+    """
+    # Add headers to avoid being blocked by Microsoft
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept': 'application/pdf,*/*',
+        'Accept-Language': 'en-US,en;q=0.9',
+        'Referer': 'https://www.microsoft.com/',
+    }
+
+    response = requests.get(pdf_url, timeout=30, headers=headers, allow_redirects=True)
+    response.raise_for_status()
+
+    # Verify we actually got a PDF
+    if not response.content.startswith(b'%PDF'):
+        raise ValueError(f"Downloaded content is not a valid PDF (Content-Type: {response.headers.get('Content-Type')})")
+
+    pdf_hash = hashlib.sha256(response.content).hexdigest()
+    return pdf_hash
+
+
+def scrape_individual_publication(driver, pub_url: str, index: int) -> Optional[Dict[str, Any]]:
+    """
+    Visit an individual publication page and extract paper link from Related Resources sidebar.
+
+    Args:
+        driver: Selenium WebDriver instance
+        pub_url: URL of the publication page
+        index: Index number for display
+
+    Returns:
+        Optional[Dict[str, Any]]: Dict containing publication data, or None if error or no paper link
+    """
+    try:
+        driver.get(pub_url)
+        time.sleep(2)
+
+        # Extract title
+        title = None
+        try:
+            title_element = driver.find_element(By.CSS_SELECTOR, "h1")
+            title = title_element.text.strip()
+        except:
+            title = driver.title
+
+        # Extract publication date
+        pub_date = None
+        try:
+            date_element = driver.find_element(By.CSS_SELECTOR, ".date, .publication-date, time")
+            pub_date = date_element.text.strip()
+        except:
+            pass
+
+        # Look for paper link in the "Related resources" sidebar ONLY
+        paper_url = None
+        arxiv_id = None
+        pdf_hash = None
+
+        try:
+            # Find the "Related resources" aside section
+            related_resources = driver.find_element(By.CSS_SELECTOR, 'aside[aria-label="Related resources"]')
+
+            # Find all buttons in this section
+            buttons = related_resources.find_elements(By.CSS_SELECTOR, "a.btn.btn-primary.btn-lg")
+
+            for button in buttons:
+                href = button.get_attribute('href')
+                if not href:
+                    continue
+
+                # Check if it's an arXiv link
+                arxiv_id_found = extract_arxiv_id_from_url(href)
+                if arxiv_id_found:
+                    paper_url = href
+                    arxiv_id = arxiv_id_found
+                    print(f"    Found arXiv link: {arxiv_id}")
+                    break
+
+                # Check if it's a PDF link
+                if '.pdf' in href.lower():
+                    paper_url = href
+                    print(f"    Found PDF link, computing hash...")
+                    # Compute hash and verify it's a valid PDF
+                    pdf_hash = compute_pdf_hash(paper_url)
+                    print(f"    PDF hash: {pdf_hash[:16]}...")
+                    break
+
+        except Exception as e:
+            print(f"    No Related resources section found or error: {e}")
+
+        # Skip publications without paper links
+        if not paper_url:
+            print(f"    No paper link found, skipping")
+            return None
+
+        pub_data = {
+            "index": index,
+            "title": title,
+            "url": pub_url,
+            "paper_url": paper_url,
+            "arxiv_id": arxiv_id,
+            "pdf_hash": pdf_hash,
+            "publication_date": pub_date
+        }
+
+        # Print summary
+        print(f"  Title: {title}")
+        print(f"  Paper URL: {paper_url}")
+        if arxiv_id:
+            print(f"  ArXiv ID: {arxiv_id}")
+        elif pdf_hash:
+            print(f"  PDF Hash: {pdf_hash[:16]}...")
+
+        return pub_data
+
+    except Exception as e:
+        print(f"  Error scraping publication {index}: {e}")
+        raise
+
+
+# ============================================================================
+# DATABASE HELPERS
+# ============================================================================
+
+@contextmanager
+def database_session():
+    """
+    Create a database session with automatic commit/rollback handling.
+
+    Yields:
+        Session: SQLAlchemy session for database operations
+
+    Raises:
+        Exception: Any database error that occurs during the transaction
+    """
+    session: Session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+# ============================================================================
+# DAG DEFINITION
+# ============================================================================
+
+@dag(
+    dag_id="daily_microsoft_research_papers",
+    start_date=pendulum.datetime(2025, 1, 1, tz="UTC"),
+    schedule="0 7 * * *",  # 7 AM daily (same as other research paper DAGs)
+    catchup=False,
+    tags=["microsoft-research", "papers"],
+    params={
+        "papers_to_add": Param(
+            type="integer",
+            default=10,
+            title="Number of Papers to Add",
+            description="Number of papers to add to the processing queue. Will scrape publications until this many papers with accessible PDFs/arXiv links are found.",
+            minimum=1,
+            maximum=200
+        )
+    },
+    doc_md="""
+    ### Daily Microsoft Research Papers DAG
+
+    This DAG scrapes papers from Microsoft Research publications page and adds them to the processing queue.
+    - Scrapes recent publications using Selenium
+    - Extracts paper URLs (both arXiv and Microsoft-hosted PDFs)
+    - Computes PDF hashes for uniqueness verification
+    - Adds papers to the processing queue for summarization
+    - When run on its daily schedule, it fetches the most recent publications.
+    - When run manually, you can customize the number of papers to add.
+
+    Note: Only publications with accessible paper links (arXiv or PDF) are added.
+    """,
+)
+def daily_microsoft_research_papers_dag():
+
+    @task
+    def scrape_publications(**context) -> List[Dict[str, Any]]:
+        """
+        Scrape Microsoft Research publications and extract paper links.
+        Stops after finding the requested number of papers with accessible links.
+
+        Returns:
+            List[Dict[str, Any]]: List of publications with paper information
+        """
+        papers_to_add = int(context["params"]["papers_to_add"])
+        print(f"Scraping Microsoft Research: {MICROSOFT_RESEARCH_URL}")
+        print(f"  Looking for {papers_to_add} papers with accessible links")
+
+        driver = setup_driver()
+
+        try:
+            driver.get(MICROSOFT_RESEARCH_URL)
+            print("Page loaded, waiting for content to render...")
+
+            # Wait for publication cards to load
+            try:
+                WebDriverWait(driver, 10).until(
+                    EC.presence_of_element_located((By.CSS_SELECTOR, "article, .publication-item, .m-publication"))
+                )
+                print("Publications detected!")
+            except Exception as e:
+                print(f"Warning: Timeout waiting for publications: {e}")
+
+            # Give extra time for JavaScript to fully render
+            time.sleep(3)
+
+            # Process publications page by page until we have enough papers
+            print(f"\n--- Processing publications to find {papers_to_add} papers ---\n")
+            result = []
+            processed_count = 0
+            current_page = 1
+            max_pages = 10  # Safety limit to avoid infinite loops
+
+            while len(result) < papers_to_add and current_page <= max_pages:
+                # Navigate to the current page
+                if current_page == 1:
+                    page_url = MICROSOFT_RESEARCH_URL
+                else:
+                    page_url = f"{MICROSOFT_RESEARCH_URL}?pg={current_page}"
+
+                print(f"\n--- Page {current_page}: {page_url} ---")
+                driver.get(page_url)
+                time.sleep(3)
+
+                # Extract publication URLs from current page
+                publication_links = []
+                try:
+                    cards = driver.find_elements(By.CSS_SELECTOR, "article.m-publication, .publication-item, article")
+
+                    for card in cards:
+                        try:
+                            link = card.find_element(By.CSS_SELECTOR, "a[href*='/publication/']")
+                            href = link.get_attribute('href')
+                            if href and href not in publication_links:
+                                publication_links.append(href)
+                        except:
+                            continue
+                except:
+                    pass
+
+                # Fallback: find all links containing '/publication/'
+                if not publication_links:
+                    all_links = driver.find_elements(By.CSS_SELECTOR, "a[href*='/publication/']")
+                    seen_urls = set()
+                    for link in all_links:
+                        href = link.get_attribute('href')
+                        if href and href not in seen_urls:
+                            seen_urls.add(href)
+                            publication_links.append(href)
+
+                print(f"  Found {len(publication_links)} publication URLs on page {current_page}")
+
+                # Process publications from this page
+                for pub_url in publication_links:
+                    # Stop if we've found enough papers
+                    if len(result) >= papers_to_add:
+                        print(f"\n  Found {papers_to_add} papers. Stopping.")
+                        break
+
+                    processed_count += 1
+                    print(f"\n  --- Processing publication #{processed_count}: {pub_url} ---")
+
+                    pub_data = scrape_individual_publication(driver, pub_url, processed_count)
+
+                    if pub_data:
+                        result.append(pub_data)
+                        print(f"    Papers found: {len(result)}/{papers_to_add}")
+
+                    time.sleep(2)  # Be nice to the server
+
+                # Stop if we've found enough papers
+                if len(result) >= papers_to_add:
+                    break
+
+                # Move to next page
+                current_page += 1
+
+            print(f"\n--- Scraping complete: Found {len(result)} papers ---")
+            return result
+
+        finally:
+            driver.quit()
+            print("\nBrowser closed")
+
+    @task
+    def print_papers_info(papers_data: List[Dict[str, Any]]) -> None:
+        """
+        Print paper information to console.
+
+        Args:
+            papers_data: List of paper data from scraper
+        """
+        if not papers_data:
+            print("No papers found with accessible links")
+            return
+
+        print(f"\n=== Microsoft Research Publications - {len(papers_data)} Found ===\n")
+
+        for rank, paper in enumerate(papers_data, 1):
+            title = paper.get('title', 'Unknown Title')
+            paper_url = paper.get('paper_url', 'N/A')
+            arxiv_id = paper.get('arxiv_id')
+            pdf_hash = paper.get('pdf_hash')
+
+            print(f"#{rank} - {title}")
+            print(f"     Paper URL: {paper_url}")
+            if arxiv_id:
+                print(f"     ArXiv ID: {arxiv_id}")
+                print(f"     ArXiv URL: https://arxiv.org/abs/{arxiv_id}")
+            elif pdf_hash:
+                print(f"     PDF Hash: {pdf_hash}")
+            print("")
+
+        print(f"\n=== End of Microsoft Research Publications ===\n")
+
+    @task
+    def add_papers_to_queue(papers_data: List[Dict[str, Any]]) -> None:
+        """
+        Add papers to processing queue.
+
+        Args:
+            papers_data: List of paper data from scraper
+        """
+        if not papers_data:
+            print("No papers to add to queue")
+            return
+
+        with database_session() as session:
+            added_count = 0
+            skipped_count = 0
+
+            for rank, paper in enumerate(papers_data, 1):
+                try:
+                    arxiv_id = paper.get('arxiv_id')
+                    paper_url = paper.get('paper_url')
+                    title = paper.get('title')
+
+                    if not paper_url:
+                        print(f"Skipping paper at rank {rank} - no paper URL")
+                        skipped_count += 1
+                        continue
+
+                    # Create popularity signal for Microsoft Research
+                    microsoft_signal = ExternalPopularitySignal(
+                        source="MicrosoftResearch",
+                        values={
+                            "publication_url": paper.get('url')
+                        },
+                        fetch_info={
+                            "publication_title": title,
+                            "publication_date": paper.get('publication_date')
+                        }
+                    )
+
+                    # Add paper to processing queue
+                    if arxiv_id:
+                        # ArXiv paper - use existing flow
+                        create_paper(
+                            db=session,
+                            arxiv_id=arxiv_id,
+                            title=title,
+                            external_popularity_signals=[microsoft_signal],
+                            initiated_by_user_id=None
+                        )
+                        print(f"Added arXiv paper {arxiv_id} to queue (rank #{rank})")
+                    else:
+                        # Non-arXiv paper - use PDF URL
+                        create_paper(
+                            db=session,
+                            pdf_url=paper_url,
+                            title=title,
+                            external_popularity_signals=[microsoft_signal],
+                            initiated_by_user_id=None
+                        )
+                        print(f"Added Microsoft-hosted paper to queue (rank #{rank})")
+
+                    added_count += 1
+                    print(f"  Title: {title[:80]}...")
+
+                except ValueError as e:
+                    # Paper already exists - this is expected and not an error
+                    if "already exists" in str(e):
+                        print(f"Skipping paper at rank {rank} - already exists in database")
+                        skipped_count += 1
+                    else:
+                        print(f"Error with paper at rank {rank}: {e}")
+                        skipped_count += 1
+                    continue
+
+                except Exception as e:
+                    print(f"Error adding paper at rank {rank}: {e}")
+                    print(f"  Skipping and continuing with next paper")
+                    skipped_count += 1
+                    continue
+
+            print(f"\n=== Processing Queue Summary ===")
+            print(f"Added: {added_count} papers")
+            print(f"Skipped: {skipped_count} papers")
+            print(f"===========================\n")
+
+    # Define task dependencies
+    papers = scrape_publications()
+    print_papers_info(papers)
+    add_papers_to_queue(papers)
+
+
+daily_microsoft_research_papers_dag()

--- a/testscripts/2025.11.14-scrape-microsoft-research/debug_page_structure.py
+++ b/testscripts/2025.11.14-scrape-microsoft-research/debug_page_structure.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Debug script to inspect the structure of a Microsoft Research publication page.
+"""
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.options import Options
+import time
+
+
+def setup_driver():
+    """Set up Chrome driver."""
+    chrome_options = Options()
+    # Don't use headless so we can see what's happening
+    # chrome_options.add_argument("--headless")
+    chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("--disable-dev-shm-usage")
+    chrome_options.add_argument("user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
+
+    driver = webdriver.Chrome(options=chrome_options)
+    return driver
+
+
+def inspect_publication_page(url: str):
+    """
+    Inspect a publication page and print all possible link elements.
+
+    Args:
+        url: Publication page URL
+    """
+    driver = setup_driver()
+
+    try:
+        print(f"Loading: {url}\n")
+        driver.get(url)
+        time.sleep(3)
+
+        # Get title
+        try:
+            title = driver.find_element(By.CSS_SELECTOR, "h1").text.strip()
+            print(f"Title: {title}\n")
+        except:
+            print("Could not find title\n")
+
+        # Find all links on the page
+        print("=" * 80)
+        print("ALL LINKS ON PAGE:")
+        print("=" * 80)
+        all_links = driver.find_elements(By.TAG_NAME, "a")
+
+        for idx, link in enumerate(all_links, 1):
+            href = link.get_attribute('href')
+            text = link.text.strip()
+            classes = link.get_attribute('class')
+
+            if href:
+                print(f"{idx}. Text: '{text}' | Classes: '{classes}'")
+                print(f"   URL: {href}")
+
+                # Highlight PDF links
+                if '.pdf' in href.lower():
+                    print(f"   *** PDF LINK ***")
+
+                print()
+
+        # Look for specific button/link patterns
+        print("\n" + "=" * 80)
+        print("LOOKING FOR SPECIFIC PATTERNS:")
+        print("=" * 80)
+
+        patterns = [
+            ("PDF links", "a[href*='.pdf']"),
+            ("Download buttons", "a.c-button, button.c-button"),
+            ("Links with 'publication' text", None),  # Custom search
+            ("Links with 'download' text", None),  # Custom search
+            ("Links with 'paper' text", None),  # Custom search
+        ]
+
+        for pattern_name, selector in patterns:
+            print(f"\n{pattern_name}:")
+            if selector:
+                try:
+                    elements = driver.find_elements(By.CSS_SELECTOR, selector)
+                    if elements:
+                        for elem in elements:
+                            href = elem.get_attribute('href')
+                            text = elem.text.strip()
+                            print(f"  - Text: '{text}' | URL: {href}")
+                    else:
+                        print(f"  None found")
+                except Exception as e:
+                    print(f"  Error: {e}")
+            else:
+                # Custom text search
+                search_text = pattern_name.split("'")[1]
+                matching = [l for l in all_links if search_text.lower() in l.text.lower()]
+                if matching:
+                    for link in matching:
+                        href = link.get_attribute('href')
+                        text = link.text.strip()
+                        print(f"  - Text: '{text}' | URL: {href}")
+                else:
+                    print(f"  None found")
+
+        input("\nPress Enter to close browser...")
+
+    finally:
+        driver.quit()
+
+
+if __name__ == "__main__":
+    # Test with one of the publications that didn't have a PDF
+    test_url = "https://www.microsoft.com/en-us/research/publication/serving-models-fast-and-slowoptimizing-heterogeneous-llm-inferencing-workloads-at-scale/"
+
+    print("Microsoft Research Publication Page Inspector")
+    print("=" * 80)
+    print(f"Testing with: {test_url}\n")
+
+    inspect_publication_page(test_url)

--- a/testscripts/2025.11.14-scrape-microsoft-research/debug_pdf_download.py
+++ b/testscripts/2025.11.14-scrape-microsoft-research/debug_pdf_download.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Debug script to see what's actually being downloaded when we request PDFs.
+"""
+
+import requests
+import hashlib
+
+
+def debug_pdf_download(pdf_url: str):
+    """
+    Download PDF and show detailed information about the response.
+
+    Args:
+        pdf_url: URL of the PDF
+    """
+    print(f"\nDownloading: {pdf_url}")
+    print(f"URL filename: {pdf_url.split('/')[-1]}")
+
+    response = requests.get(pdf_url, timeout=30, allow_redirects=True)
+
+    print(f"\nResponse Status: {response.status_code}")
+    print(f"Content-Type: {response.headers.get('Content-Type')}")
+    print(f"Content-Length: {response.headers.get('Content-Length')}")
+    print(f"Size downloaded: {len(response.content)} bytes")
+    print(f"Final URL: {response.url}")
+
+    # Check if redirected
+    if response.history:
+        print(f"\nRedirects:")
+        for i, resp in enumerate(response.history):
+            print(f"  {i+1}. {resp.status_code} -> {resp.url}")
+
+    # Check first bytes to see if it's actually a PDF
+    first_bytes = response.content[:100]
+    print(f"\nFirst 100 bytes: {first_bytes[:100]}")
+
+    # Check if it starts with PDF header
+    if first_bytes.startswith(b'%PDF'):
+        print("✓ Valid PDF header")
+    else:
+        print("✗ NOT a valid PDF! Might be HTML error page")
+
+    # Compute hash
+    pdf_hash = hashlib.sha256(response.content).hexdigest()
+    print(f"\nSHA256 Hash: {pdf_hash}")
+
+    # Save to file for inspection
+    filename = f"debug_{pdf_url.split('/')[-1]}"
+    with open(filename, 'wb') as f:
+        f.write(response.content)
+    print(f"Saved to: {filename}")
+
+    return pdf_hash
+
+
+if __name__ == "__main__":
+    # Test the three PDFs
+    pdfs = [
+        "https://www.microsoft.com/en-us/research/wp-content/uploads/2025/07/Enter-Exit-SP26.pdf",
+        "https://www.microsoft.com/en-us/research/wp-content/uploads/2025/10/eurosys26-spring-final215.pdf",
+        "https://www.microsoft.com/en-us/research/wp-content/uploads/2025/04/niyama.pdf",
+    ]
+
+    print("=" * 80)
+    print("PDF Download Debug")
+    print("=" * 80)
+
+    hashes = []
+    for i, pdf_url in enumerate(pdfs, 1):
+        print(f"\n{'=' * 80}")
+        print(f"PDF #{i}")
+        print(f"{'=' * 80}")
+        pdf_hash = debug_pdf_download(pdf_url)
+        hashes.append(pdf_hash)
+
+    print(f"\n{'=' * 80}")
+    print("HASH COMPARISON:")
+    print(f"{'=' * 80}")
+    print(f"Total PDFs: {len(hashes)}")
+    print(f"Unique hashes: {len(set(hashes))}")
+
+    for i, h in enumerate(hashes, 1):
+        print(f"  PDF {i}: {h}")

--- a/testscripts/2025.11.14-scrape-microsoft-research/scrape_microsoft_research.py
+++ b/testscripts/2025.11.14-scrape-microsoft-research/scrape_microsoft_research.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""
+Test script to scrape papers from Microsoft Research publications page.
+This script uses Selenium to handle JavaScript-rendered content and pagination.
+
+The page structure:
+- Main listing: https://www.microsoft.com/en-us/research/publications
+- Each publication card has a link to individual publication page
+- Individual page has a "Publication" button that links to the actual paper PDF
+- We need to hash the PDF for uniqueness (non-arXiv papers)
+"""
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.chrome.options import Options
+import json
+import time
+import hashlib
+import requests
+from typing import List, Dict, Any, Optional
+
+
+# ============================================================================
+# CONSTANTS
+# ============================================================================
+
+MICROSOFT_RESEARCH_URL = "https://www.microsoft.com/en-us/research/publications"
+MAX_PUBLICATIONS_TO_PROCESS = 10
+
+
+# ============================================================================
+# HELPER FUNCTIONS
+# ============================================================================
+
+def setup_driver():
+    """
+    Set up Selenium Chrome driver with headless options.
+
+    Returns:
+        webdriver.Chrome: Configured Chrome WebDriver instance
+    """
+    chrome_options = Options()
+    chrome_options.add_argument("--headless")
+    chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("--disable-dev-shm-usage")
+    chrome_options.add_argument("--disable-gpu")
+    chrome_options.add_argument("user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
+
+    driver = webdriver.Chrome(options=chrome_options)
+    return driver
+
+
+def compute_pdf_hash(pdf_url: str) -> Optional[str]:
+    """
+    Download PDF and compute its hash for uniqueness.
+
+    Args:
+        pdf_url: URL of the PDF to download
+
+    Returns:
+        Optional[str]: SHA256 hash of the PDF content, or None if error
+    """
+    try:
+        print(f"    Downloading PDF to compute hash...")
+
+        # Add headers to avoid being blocked by Microsoft
+        headers = {
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            'Accept': 'application/pdf,*/*',
+            'Accept-Language': 'en-US,en;q=0.9',
+            'Referer': 'https://www.microsoft.com/',
+        }
+
+        response = requests.get(pdf_url, timeout=30, headers=headers, allow_redirects=True)
+        response.raise_for_status()
+
+        # Verify we actually got a PDF
+        if not response.content.startswith(b'%PDF'):
+            print(f"    WARNING: Downloaded content is not a PDF (Content-Type: {response.headers.get('Content-Type')})")
+            return None
+
+        pdf_hash = hashlib.sha256(response.content).hexdigest()
+        print(f"    PDF hash: {pdf_hash[:16]}... (size: {len(response.content)} bytes)")
+        return pdf_hash
+
+    except Exception as e:
+        print(f"    Error computing PDF hash: {e}")
+        return None
+
+
+def extract_arxiv_id_from_url(url: str) -> Optional[str]:
+    """
+    Extract arXiv ID from URL.
+
+    Args:
+        url: URL that may contain an arXiv ID
+
+    Returns:
+        Optional[str]: Extracted arXiv ID or None if not found
+    """
+    import re
+    arxiv_match = re.search(r'arxiv\.org/(?:abs|pdf)/(\d+\.\d+)', url, re.I)
+    if arxiv_match:
+        return arxiv_match.group(1)
+    return None
+
+
+def scrape_individual_publication(driver, pub_url: str, index: int) -> Optional[Dict[str, Any]]:
+    """
+    Visit an individual publication page and extract paper link from Related Resources sidebar.
+
+    Args:
+        driver: Selenium WebDriver instance
+        pub_url: URL of the publication page
+        index: Index number for display
+
+    Returns:
+        Optional[Dict[str, Any]]: Dict containing publication data, or None if error
+    """
+    try:
+        driver.get(pub_url)
+        time.sleep(2)
+
+        # Extract title
+        title = None
+        try:
+            title_element = driver.find_element(By.CSS_SELECTOR, "h1")
+            title = title_element.text.strip()
+        except:
+            title = driver.title
+
+        # Extract publication date
+        pub_date = None
+        try:
+            date_element = driver.find_element(By.CSS_SELECTOR, ".date, .publication-date, time")
+            pub_date = date_element.text.strip()
+        except:
+            pass
+
+        # Look for paper link in the "Related resources" sidebar ONLY
+        paper_url = None
+        arxiv_id = None
+        pdf_hash = None
+
+        try:
+            # Find the "Related resources" aside section
+            related_resources = driver.find_element(By.CSS_SELECTOR, 'aside[aria-label="Related resources"]')
+
+            # Find all buttons in this section
+            buttons = related_resources.find_elements(By.CSS_SELECTOR, "a.btn.btn-primary.btn-lg")
+
+            for button in buttons:
+                href = button.get_attribute('href')
+                if not href:
+                    continue
+
+                # Check if it's an arXiv link
+                arxiv_id_found = extract_arxiv_id_from_url(href)
+                if arxiv_id_found:
+                    paper_url = href
+                    arxiv_id = arxiv_id_found
+                    print(f"    Found arXiv link: {arxiv_id}")
+                    break
+
+                # Check if it's a PDF link
+                if '.pdf' in href.lower():
+                    paper_url = href
+                    print(f"    Found PDF link")
+                    pdf_hash = compute_pdf_hash(paper_url)
+                    break
+
+        except Exception as e:
+            print(f"    No Related resources section found or error: {e}")
+
+        pub_data = {
+            "index": index,
+            "title": title,
+            "url": pub_url,
+            "paper_url": paper_url,
+            "arxiv_id": arxiv_id,
+            "pdf_hash": pdf_hash,
+            "publication_date": pub_date
+        }
+
+        # Print summary
+        print(f"  Title: {title}")
+        if paper_url:
+            print(f"  Paper URL: {paper_url}")
+            if arxiv_id:
+                print(f"  ArXiv ID: {arxiv_id}")
+            elif pdf_hash:
+                print(f"  PDF Hash: {pdf_hash[:16]}...")
+        else:
+            print(f"  Paper URL: None")
+
+        if pub_date:
+            print(f"  Date: {pub_date}")
+
+        return pub_data
+
+    except Exception as e:
+        print(f"  Error scraping publication {index}: {e}")
+        return None
+
+
+def scrape_publications_page(url: str = MICROSOFT_RESEARCH_URL) -> Dict[str, Any]:
+    """
+    Scrape Microsoft Research publications page and extract paper information.
+
+    Args:
+        url: URL of the publications page
+
+    Returns:
+        Dict containing list of publications with paper information
+    """
+    print(f"Fetching publications page: {url}")
+    print("Initializing Selenium Chrome driver...")
+
+    driver = setup_driver()
+
+    try:
+        driver.get(url)
+        print("Page loaded, waiting for content to render...")
+
+        # Wait for publication cards to load
+        try:
+            WebDriverWait(driver, 10).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, "article, .publication-item, .m-publication"))
+            )
+            print("Publications detected!")
+        except Exception as e:
+            print(f"Warning: Timeout waiting for publications: {e}")
+
+        # Give extra time for JavaScript to fully render
+        time.sleep(3)
+
+        # Find all publication links
+        print("\n--- Extracting publication URLs ---\n")
+
+        # Try different selectors for publication cards/links
+        publication_links = []
+
+        # Try to find publication cards
+        try:
+            # Look for article elements or publication cards
+            cards = driver.find_elements(By.CSS_SELECTOR, "article.m-publication, .publication-item, article")
+
+            for card in cards:
+                try:
+                    # Find the link within each card
+                    link = card.find_element(By.CSS_SELECTOR, "a[href*='/publication/']")
+                    href = link.get_attribute('href')
+                    if href and href not in publication_links:
+                        publication_links.append(href)
+                except:
+                    continue
+        except:
+            pass
+
+        # Fallback: find all links containing '/publication/'
+        if not publication_links:
+            all_links = driver.find_elements(By.CSS_SELECTOR, "a[href*='/publication/']")
+            seen_urls = set()
+            for link in all_links:
+                href = link.get_attribute('href')
+                if href and href not in seen_urls:
+                    seen_urls.add(href)
+                    publication_links.append(href)
+
+        print(f"Found {len(publication_links)} publication URLs")
+
+        # Process limited number of publications
+        result = {
+            "url": url,
+            "publications": []
+        }
+
+        pubs_to_process = publication_links[:MAX_PUBLICATIONS_TO_PROCESS]
+        print(f"\nProcessing {len(pubs_to_process)} publications (out of {len(publication_links)} found)...\n")
+
+        for idx, pub_url in enumerate(pubs_to_process, 1):
+            print(f"\n--- Processing publication #{idx}/{len(pubs_to_process)}: {pub_url} ---")
+            pub_data = scrape_individual_publication(driver, pub_url, idx)
+            if pub_data:
+                result["publications"].append(pub_data)
+            time.sleep(2)  # Be nice to the server
+
+        # Check if there's pagination
+        print("\n--- Checking for pagination ---")
+        try:
+            next_button = driver.find_element(By.CSS_SELECTOR, ".pagination a.next, button.next, a[aria-label*='next']")
+            print(f"Pagination found! Next button available.")
+            print(f"Next button text: {next_button.text}")
+        except:
+            print("No obvious pagination found")
+
+        return result
+
+    finally:
+        driver.quit()
+        print("\nBrowser closed")
+
+
+# ============================================================================
+# MAIN ENTRYPOINT
+# ============================================================================
+
+def main():
+    """Main function to run the scraper test."""
+    import os
+
+    print("=" * 80)
+    print("Microsoft Research Publications Scraper Test (Selenium)")
+    print("=" * 80)
+    print()
+
+    # Scrape first page
+    result = scrape_publications_page()
+
+    # Save results to file
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    output_file = os.path.join(script_dir, "microsoft_research_scrape_results.json")
+    with open(output_file, 'w', encoding='utf-8') as f:
+        json.dump(result, f, indent=2, ensure_ascii=False)
+
+    print(f"\n{'=' * 80}")
+    print(f"Results saved to: {output_file}")
+    print(f"Total publications processed: {len(result.get('publications', []))}")
+
+    # Print summary
+    all_pubs = result.get('publications', [])
+    pubs_with_paper_url = [p for p in all_pubs if p.get('paper_url')]
+    pubs_with_arxiv = [p for p in all_pubs if p.get('arxiv_id')]
+    pubs_with_pdf = [p for p in all_pubs if p.get('pdf_hash')]
+    pubs_without_paper = [p for p in all_pubs if not p.get('paper_url')]
+
+    print(f"Publications with paper links: {len(pubs_with_paper_url)}")
+    print(f"  - ArXiv papers: {len(pubs_with_arxiv)}")
+    print(f"  - PDF papers (with hash): {len(pubs_with_pdf)}")
+    print(f"Publications without paper links: {len(pubs_without_paper)}")
+    print(f"{'=' * 80}")
+
+
+if __name__ == "__main__":
+    main()

--- a/testscripts/2025.11.14-scrape-microsoft-research/test_fixed_hash.py
+++ b/testscripts/2025.11.14-scrape-microsoft-research/test_fixed_hash.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Test the fixed PDF hash computation with proper headers.
+"""
+
+import requests
+import hashlib
+
+
+def compute_pdf_hash_fixed(pdf_url: str) -> str:
+    """
+    Download PDF with proper headers and compute its hash.
+
+    Args:
+        pdf_url: URL of the PDF
+
+    Returns:
+        str: SHA256 hash of the PDF content
+    """
+    print(f"Downloading: {pdf_url}")
+
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept': 'application/pdf,*/*',
+        'Accept-Language': 'en-US,en;q=0.9',
+        'Referer': 'https://www.microsoft.com/',
+    }
+
+    response = requests.get(pdf_url, timeout=30, headers=headers, allow_redirects=True)
+    response.raise_for_status()
+
+    print(f"  Content-Type: {response.headers.get('Content-Type')}")
+    print(f"  Size: {len(response.content)} bytes")
+
+    # Verify it's a PDF
+    if response.content.startswith(b'%PDF'):
+        print(f"  ✓ Valid PDF")
+    else:
+        print(f"  ✗ NOT a PDF!")
+        print(f"  First 100 bytes: {response.content[:100]}")
+
+    pdf_hash = hashlib.sha256(response.content).hexdigest()
+    print(f"  Hash: {pdf_hash}")
+
+    return pdf_hash
+
+
+if __name__ == "__main__":
+    # Test the three PDFs
+    pdfs = [
+        "https://www.microsoft.com/en-us/research/wp-content/uploads/2025/07/Enter-Exit-SP26.pdf",
+        "https://www.microsoft.com/en-us/research/wp-content/uploads/2025/10/eurosys26-spring-final215.pdf",
+        "https://www.microsoft.com/en-us/research/wp-content/uploads/2025/04/niyama.pdf",
+    ]
+
+    print("=" * 80)
+    print("Testing Fixed PDF Hash Computation")
+    print("=" * 80)
+
+    hashes = []
+    for i, pdf_url in enumerate(pdfs, 1):
+        print(f"\n{i}. {pdf_url.split('/')[-1]}")
+        pdf_hash = compute_pdf_hash_fixed(pdf_url)
+        hashes.append(pdf_hash)
+
+    print(f"\n{'=' * 80}")
+    print("HASH COMPARISON:")
+    print(f"{'=' * 80}")
+    print(f"Total PDFs: {len(hashes)}")
+    print(f"Unique hashes: {len(set(hashes))}")
+
+    if len(set(hashes)) == len(hashes):
+        print("\n✓ SUCCESS! All PDFs have unique hashes!")
+    else:
+        print("\n✗ FAILURE! Some PDFs have duplicate hashes!")
+
+    for i, h in enumerate(hashes, 1):
+        print(f"  PDF {i}: {h}")

--- a/testscripts/2025.11.14-scrape-microsoft-research/test_pagination.py
+++ b/testscripts/2025.11.14-scrape-microsoft-research/test_pagination.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Test script to verify pagination on Microsoft Research publications page.
+"""
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.chrome.options import Options
+import time
+
+
+MICROSOFT_RESEARCH_URL = "https://www.microsoft.com/en-us/research/publications"
+
+
+def setup_driver():
+    """Set up Selenium Chrome driver."""
+    chrome_options = Options()
+    chrome_options.add_argument("--headless")
+    chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("--disable-dev-shm-usage")
+    chrome_options.add_argument("--disable-gpu")
+    chrome_options.add_argument("user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
+
+    driver = webdriver.Chrome(options=chrome_options)
+    return driver
+
+
+def test_pagination():
+    """Test if pagination exists and how to navigate it."""
+    driver = setup_driver()
+
+    try:
+        print("=" * 80)
+        print("Testing Microsoft Research Pagination")
+        print("=" * 80)
+
+        driver.get(MICROSOFT_RESEARCH_URL)
+        print(f"\nLoading: {MICROSOFT_RESEARCH_URL}")
+        time.sleep(3)
+
+        # Count publications on first page
+        cards = driver.find_elements(By.CSS_SELECTOR, "article.m-publication, .publication-item, article")
+        print(f"Publications found on page 1: {len(cards)}")
+
+        # Look for pagination controls
+        print("\n--- Looking for pagination elements ---")
+
+        # Try different pagination selectors
+        pagination_selectors = [
+            (".pagination", "Pagination container"),
+            (".pagination a.next", "Next button (link)"),
+            ("button.next", "Next button"),
+            ("a[aria-label*='next']", "Next link (aria-label)"),
+            (".pager", "Pager container"),
+            ("[class*='pagination']", "Any pagination class"),
+            ("[class*='pager']", "Any pager class"),
+            ("nav[role='navigation']", "Navigation role"),
+        ]
+
+        found_pagination = False
+        for selector, description in pagination_selectors:
+            try:
+                elements = driver.find_elements(By.CSS_SELECTOR, selector)
+                if elements:
+                    print(f"\n✓ Found: {description}")
+                    print(f"  Selector: {selector}")
+                    print(f"  Count: {len(elements)}")
+                    for i, elem in enumerate(elements[:3]):  # Show first 3
+                        print(f"  Element {i+1}:")
+                        print(f"    Tag: {elem.tag_name}")
+                        print(f"    Text: {elem.text[:100]}")
+                        print(f"    Classes: {elem.get_attribute('class')}")
+                        if elem.tag_name == 'a':
+                            print(f"    Href: {elem.get_attribute('href')}")
+                    found_pagination = True
+            except Exception as e:
+                pass
+
+        if not found_pagination:
+            print("\n✗ No pagination elements found")
+
+        # Check page source for pagination-related terms
+        print("\n--- Checking page source for pagination keywords ---")
+        page_source = driver.page_source.lower()
+        keywords = ['pagination', 'pager', 'next page', 'load more', 'show more']
+        for keyword in keywords:
+            if keyword in page_source:
+                print(f"✓ Found keyword: '{keyword}'")
+
+        # Try scrolling to see if it's infinite scroll
+        print("\n--- Testing for infinite scroll ---")
+        initial_count = len(driver.find_elements(By.CSS_SELECTOR, "article.m-publication, .publication-item, article"))
+        print(f"Initial publication count: {initial_count}")
+
+        # Scroll to bottom
+        driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+        time.sleep(3)
+
+        # Check if more loaded
+        after_scroll_count = len(driver.find_elements(By.CSS_SELECTOR, "article.m-publication, .publication-item, article"))
+        print(f"After scroll count: {after_scroll_count}")
+
+        if after_scroll_count > initial_count:
+            print(f"✓ Infinite scroll detected! {after_scroll_count - initial_count} more publications loaded")
+        else:
+            print("✗ No infinite scroll detected")
+
+        # Save page source for manual inspection
+        with open('microsoft_research_page_source.html', 'w', encoding='utf-8') as f:
+            f.write(driver.page_source)
+        print("\n✓ Page source saved to: microsoft_research_page_source.html")
+
+    finally:
+        driver.quit()
+        print("\nBrowser closed")
+
+
+if __name__ == "__main__":
+    test_pagination()

--- a/testscripts/2025.11.14-scrape-microsoft-research/test_pagination_navigation.py
+++ b/testscripts/2025.11.14-scrape-microsoft-research/test_pagination_navigation.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Test script to verify pagination navigation on Microsoft Research.
+"""
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.chrome.options import Options
+import time
+
+
+MICROSOFT_RESEARCH_URL = "https://www.microsoft.com/en-us/research/publications"
+
+
+def setup_driver():
+    """Set up Selenium Chrome driver."""
+    chrome_options = Options()
+    chrome_options.add_argument("--headless")
+    chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("--disable-dev-shm-usage")
+    chrome_options.add_argument("--disable-gpu")
+    chrome_options.add_argument("user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
+
+    driver = webdriver.Chrome(options=chrome_options)
+    return driver
+
+
+def get_publication_urls(driver):
+    """Get all publication URLs on current page."""
+    cards = driver.find_elements(By.CSS_SELECTOR, "article.m-publication, .publication-item, article")
+    urls = []
+    for card in cards:
+        try:
+            link = card.find_element(By.CSS_SELECTOR, "a[href*='/publication/']")
+            href = link.get_attribute('href')
+            if href and href not in urls:
+                urls.append(href)
+        except:
+            continue
+    return urls
+
+
+def test_pagination_navigation():
+    """Test navigating through pagination."""
+    driver = setup_driver()
+
+    try:
+        print("=" * 80)
+        print("Testing Microsoft Research Pagination Navigation")
+        print("=" * 80)
+
+        driver.get(MICROSOFT_RESEARCH_URL)
+        print(f"\nLoading: {MICROSOFT_RESEARCH_URL}")
+        time.sleep(3)
+
+        # Get publications from page 1
+        page1_urls = get_publication_urls(driver)
+        print(f"\nPage 1: Found {len(page1_urls)} publication URLs")
+        print(f"  First URL: {page1_urls[0] if page1_urls else 'None'}")
+        print(f"  Current URL: {driver.current_url}")
+
+        # Try to find and click "Next" button
+        print("\n--- Attempting to navigate to page 2 ---")
+
+        # Try different next button selectors
+        next_selectors = [
+            ".pagination a.next",
+            "a[aria-label='Next']",
+            ".pagination li.next a",
+            ".pagination a[rel='next']",
+        ]
+
+        next_clicked = False
+        for selector in next_selectors:
+            try:
+                print(f"Trying selector: {selector}")
+                next_button = driver.find_element(By.CSS_SELECTOR, selector)
+                print(f"  Found next button!")
+                print(f"  Text: {next_button.text}")
+                print(f"  Href: {next_button.get_attribute('href')}")
+
+                # Click it
+                driver.execute_script("arguments[0].click();", next_button)
+                next_clicked = True
+                print(f"  ✓ Clicked!")
+                break
+            except Exception as e:
+                print(f"  Failed: {e}")
+                continue
+
+        if not next_clicked:
+            print("\n✗ Could not find or click Next button")
+            print("\n--- Looking for all links in pagination ---")
+            pagination = driver.find_element(By.CSS_SELECTOR, ".pagination")
+            all_links = pagination.find_elements(By.TAG_NAME, "a")
+            for i, link in enumerate(all_links):
+                print(f"  Link {i+1}: text='{link.text}' href='{link.get_attribute('href')}'")
+            return
+
+        # Wait for page to load
+        time.sleep(3)
+
+        # Get publications from page 2
+        page2_urls = get_publication_urls(driver)
+        print(f"\nPage 2: Found {len(page2_urls)} publication URLs")
+        print(f"  First URL: {page2_urls[0] if page2_urls else 'None'}")
+        print(f"  Current URL: {driver.current_url}")
+
+        # Verify we got different publications
+        if page1_urls and page2_urls:
+            overlap = set(page1_urls) & set(page2_urls)
+            print(f"\n--- Results ---")
+            print(f"Page 1 URLs: {len(page1_urls)}")
+            print(f"Page 2 URLs: {len(page2_urls)}")
+            print(f"Overlap: {len(overlap)}")
+
+            if len(overlap) == 0:
+                print("✓ SUCCESS! Pagination works - different publications on each page")
+            else:
+                print("✗ WARNING! Some publications appear on both pages")
+
+        # Try clicking next again to get to page 3
+        print("\n--- Attempting to navigate to page 3 ---")
+        try:
+            next_button = driver.find_element(By.CSS_SELECTOR, ".pagination a[aria-label='Next']")
+            driver.execute_script("arguments[0].click();", next_button)
+            time.sleep(3)
+
+            page3_urls = get_publication_urls(driver)
+            print(f"\nPage 3: Found {len(page3_urls)} publication URLs")
+            print(f"  First URL: {page3_urls[0] if page3_urls else 'None'}")
+            print(f"  Current URL: {driver.current_url}")
+
+            if page2_urls and page3_urls:
+                overlap = set(page2_urls) & set(page3_urls)
+                print(f"Overlap with page 2: {len(overlap)}")
+        except Exception as e:
+            print(f"Could not navigate to page 3: {e}")
+
+    finally:
+        driver.quit()
+        print("\nBrowser closed")
+
+
+if __name__ == "__main__":
+    test_pagination_navigation()

--- a/testscripts/2025.11.14-scrape-microsoft-research/test_pagination_simple.py
+++ b/testscripts/2025.11.14-scrape-microsoft-research/test_pagination_simple.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Simple test to verify pagination works by URL parameter.
+"""
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.options import Options
+import time
+
+
+def setup_driver():
+    """Set up Selenium Chrome driver."""
+    chrome_options = Options()
+    chrome_options.add_argument("--headless")
+    chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("--disable-dev-shm-usage")
+    chrome_options.add_argument("--disable-gpu")
+    chrome_options.add_argument("user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
+
+    driver = webdriver.Chrome(options=chrome_options)
+    return driver
+
+
+def get_publication_urls(driver):
+    """Get all publication URLs on current page."""
+    cards = driver.find_elements(By.CSS_SELECTOR, "article.m-publication, .publication-item, article")
+    urls = []
+    for card in cards:
+        try:
+            link = card.find_element(By.CSS_SELECTOR, "a[href*='/publication/']")
+            href = link.get_attribute('href')
+            if href and href not in urls:
+                urls.append(href)
+        except:
+            continue
+    return urls
+
+
+def test_pagination_by_url():
+    """Test pagination by directly visiting page URLs."""
+    driver = setup_driver()
+
+    try:
+        print("=" * 80)
+        print("Testing Microsoft Research Pagination by URL")
+        print("=" * 80)
+
+        pages_to_test = [
+            "https://www.microsoft.com/en-us/research/publications/",  # Page 1
+            "https://www.microsoft.com/en-us/research/publications/?pg=2",  # Page 2
+            "https://www.microsoft.com/en-us/research/publications/?pg=3",  # Page 3
+        ]
+
+        all_urls = []
+
+        for page_num, url in enumerate(pages_to_test, 1):
+            print(f"\n--- Page {page_num}: {url} ---")
+            driver.get(url)
+            time.sleep(3)
+
+            pub_urls = get_publication_urls(driver)
+            print(f"Found {len(pub_urls)} publications")
+            if pub_urls:
+                print(f"First: {pub_urls[0]}")
+                print(f"Last: {pub_urls[-1]}")
+
+            all_urls.append(set(pub_urls))
+
+        # Check for overlap
+        print(f"\n{'=' * 80}")
+        print("Checking for overlaps:")
+        print(f"{'=' * 80}")
+
+        for i in range(len(all_urls) - 1):
+            overlap = all_urls[i] & all_urls[i + 1]
+            print(f"Page {i+1} vs Page {i+2}: {len(overlap)} overlapping publications")
+
+        if all(len(all_urls[i] & all_urls[i + 1]) == 0 for i in range(len(all_urls) - 1)):
+            print("\n✓ SUCCESS! Pagination works - all pages have unique publications")
+        else:
+            print("\n✗ WARNING! Some pages have overlapping publications")
+
+    finally:
+        driver.quit()
+        print("\nBrowser closed")
+
+
+if __name__ == "__main__":
+    test_pagination_by_url()

--- a/testscripts/2025.11.14-scrape-microsoft-research/verify_pdf_hashes.py
+++ b/testscripts/2025.11.14-scrape-microsoft-research/verify_pdf_hashes.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Verify that the PDF hashes are actually different by downloading them separately.
+"""
+
+import hashlib
+import requests
+
+
+def compute_pdf_hash(pdf_url: str) -> str:
+    """
+    Download PDF and compute its hash.
+
+    Args:
+        pdf_url: URL of the PDF
+
+    Returns:
+        str: SHA256 hash of the PDF content
+    """
+    print(f"Downloading: {pdf_url}")
+    response = requests.get(pdf_url, timeout=30)
+    response.raise_for_status()
+
+    print(f"  Size: {len(response.content)} bytes")
+
+    pdf_hash = hashlib.sha256(response.content).hexdigest()
+    print(f"  Hash: {pdf_hash}")
+    return pdf_hash
+
+
+if __name__ == "__main__":
+    # The three PDFs from our test results
+    pdfs = [
+        "https://www.microsoft.com/en-us/research/wp-content/uploads/2025/07/Enter-Exit-SP26.pdf",
+        "https://www.microsoft.com/en-us/research/wp-content/uploads/2025/10/eurosys26-spring-final215.pdf",
+        "https://www.microsoft.com/en-us/research/wp-content/uploads/2025/04/niyama.pdf",
+    ]
+
+    print("=" * 80)
+    print("Verifying PDF hashes")
+    print("=" * 80)
+    print()
+
+    hashes = []
+    for idx, pdf_url in enumerate(pdfs, 1):
+        print(f"\n{idx}. {pdf_url.split('/')[-1]}")
+        pdf_hash = compute_pdf_hash(pdf_url)
+        hashes.append(pdf_hash)
+        print()
+
+    print("=" * 80)
+    print("HASH COMPARISON:")
+    print("=" * 80)
+
+    unique_hashes = set(hashes)
+    print(f"Total PDFs: {len(hashes)}")
+    print(f"Unique hashes: {len(unique_hashes)}")
+
+    if len(unique_hashes) == len(hashes):
+        print("\nAll PDFs are unique!")
+    else:
+        print("\nWARNING: Some PDFs have the same hash!")
+        for i, h in enumerate(hashes, 1):
+            print(f"  PDF {i}: {h}")


### PR DESCRIPTION
- Implements daily_microsoft_research_papers DAG to scrape Microsoft Research publications
- Scrapes both arXiv papers and Microsoft-hosted PDFs from publication pages
- Uses proper browser headers to avoid being blocked by Microsoft servers
- Computes PDF hashes for uniqueness verification (critical for deduplication)