### PR TITLE
Fix: added source MicrosoftResearch to ExternalPopularitySignal

### DIFF
--- a/airflow/dags/daily_microsoft_research_papers_dag.py
+++ b/airflow/dags/daily_microsoft_research_papers_dag.py
@@ -443,12 +443,9 @@ def daily_microsoft_research_papers_dag():
                     # Create popularity signal for Microsoft Research
                     microsoft_signal = ExternalPopularitySignal(
                         source="MicrosoftResearch",
-                        values={
-                            "publication_url": paper.get('url')
-                        },
+                        values={},
                         fetch_info={
-                            "publication_title": title,
-                            "publication_date": paper.get('publication_date')
+                            "publication_url": paper.get('url'),
                         }
                     )
 

--- a/papers/models.py
+++ b/papers/models.py
@@ -27,7 +27,7 @@ class Section(BaseModel):
 
 class ExternalPopularitySignal(BaseModel):
     """External popularity metrics from various sources. This will be used in ranking papers."""
-    source: Literal["HuggingFace", "AlphaXiv", "GoogleResearch"]  # Expandable to more sources
+    source: Literal["HuggingFace", "AlphaXiv", "GoogleResearch", "MicrosoftResearch"]  # Expandable to more sources
     values: Dict[str, Any]  # Flexible values per source
     fetch_info: Dict[str, Any]  # Refetch metadata per source
     updated_at: datetime = Field(default_factory=datetime.utcnow)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds MicrosoftResearch as a valid popularity signal source and updates the Microsoft Research DAG to send publication_url in fetch_info with empty values.
> 
> - **Models**:
>   - Update `ExternalPopularitySignal` to include `"MicrosoftResearch"` in `source` enum.
> - **Airflow/DAG**:
>   - In `airflow/dags/daily_microsoft_research_papers_dag.py`, adjust `ExternalPopularitySignal` construction for Microsoft Research:
>     - Set `values={}`.
>     - Move `"publication_url"` to `fetch_info`.
>     - Remove `"publication_title"` and `"publication_date"` from `fetch_info`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31c6788f65a8b14cc6c86ac85d7b5d2f7af05538. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->