### PR TITLE
fix web/src/services/auth.ts: use NEXT_PUBLIC_SITE_URL for magic link redirect instead of window.location.origin

### DIFF
--- a/web/src/services/auth.ts
+++ b/web/src/services/auth.ts
@@ -14,6 +14,12 @@ import { createClient } from '@/lib/supabase/client';
 import type { User, AuthError, SupabaseClient } from '@supabase/supabase-js';
 
 // ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || '';
+
+// ============================================================================
 // TYPES
 // ============================================================================
 
@@ -87,7 +93,7 @@ export async function signInWithMagicLink(
   const { error } = await supabase.auth.signInWithOtp({
     email,
     options: {
-      emailRedirectTo: emailRedirectTo || `${window.location.origin}/auth/callback`,
+      emailRedirectTo: emailRedirectTo || `${SITE_URL}/auth/callback`,
     },
   });
   return { error };


### PR DESCRIPTION
fix web/src/services/auth.ts: use NEXT_PUBLIC_SITE_URL for magic link redirect instead of window.location.origin
