### PR TITLE
Add semantic paper search with OpenRouter embeddings

### DIFF
--- a/migrations/versions/20260305_000030_fix_match_rpc_drop_thumbnail.py
+++ b/migrations/versions/20260305_000030_fix_match_rpc_drop_thumbnail.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '20260305_000030'
+down_revision = '20260305_000029'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """
+    Update match_papers_by_embedding to remove thumbnail_data_url
+    (column was dropped in 20260305_000029).
+    """
+    connection = op.get_bind()
+    connection.execute(sa.text(
+        "DROP FUNCTION IF EXISTS match_papers_by_embedding(vector, int, text[])"
+    ))
+    connection.execute(sa.text("""
+        CREATE OR REPLACE FUNCTION match_papers_by_embedding(
+            query_embedding vector(1536),
+            match_count int DEFAULT 20,
+            exclude_uuids text[] DEFAULT '{}'
+        )
+        RETURNS TABLE (
+            paper_uuid varchar,
+            title varchar,
+            authors text,
+            finished_at timestamp,
+            embedding vector(1536),
+            external_popularity_signals json,
+            similarity double precision
+        ) AS $$
+        BEGIN
+            RETURN QUERY
+            SELECT
+                p.paper_uuid, p.title, p.authors,
+                p.finished_at, p.embedding, p.external_popularity_signals,
+                (1.0 - (p.embedding <=> query_embedding))::double precision AS similarity
+            FROM papers p
+            WHERE p.status = 'completed'
+                AND p.embedding IS NOT NULL
+                AND p.paper_uuid != ALL(exclude_uuids)
+            ORDER BY p.embedding <=> query_embedding
+            LIMIT match_count;
+        END;
+        $$ LANGUAGE plpgsql STABLE;
+    """))
+
+
+def downgrade() -> None:
+    """
+    Restore match_papers_by_embedding with thumbnail_data_url.
+    """
+    connection = op.get_bind()
+    connection.execute(sa.text(
+        "DROP FUNCTION IF EXISTS match_papers_by_embedding(vector, int, text[])"
+    ))
+    connection.execute(sa.text("""
+        CREATE OR REPLACE FUNCTION match_papers_by_embedding(
+            query_embedding vector(1536),
+            match_count int DEFAULT 20,
+            exclude_uuids text[] DEFAULT '{}'
+        )
+        RETURNS TABLE (
+            paper_uuid text,
+            title text,
+            authors text,
+            thumbnail_data_url text,
+            finished_at timestamptz,
+            embedding vector(1536),
+            external_popularity_signals jsonb,
+            similarity float
+        ) AS $$
+        BEGIN
+            RETURN QUERY
+            SELECT
+                p.paper_uuid, p.title, p.authors, p.thumbnail_data_url,
+                p.finished_at, p.embedding, p.external_popularity_signals,
+                1.0 - (p.embedding <=> query_embedding) AS similarity
+            FROM papers p
+            WHERE p.status = 'completed'
+                AND p.embedding IS NOT NULL
+                AND p.paper_uuid != ALL(exclude_uuids)
+            ORDER BY p.embedding <=> query_embedding
+            LIMIT match_count;
+        END;
+        $$ LANGUAGE plpgsql STABLE;
+    """))

--- a/web/src/app/api/papers/search/route.ts
+++ b/web/src/app/api/papers/search/route.ts
@@ -1,0 +1,44 @@
+/**
+ * Search API Route
+ *
+ * Accepts a text query and returns semantically similar papers
+ * using OpenRouter embeddings + pgvector similarity search.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { searchPapers } from '@/services/search.service';
+import type { MinimalPaper } from '@/types/paper';
+
+interface SearchResponse {
+  items: MinimalPaper[];
+}
+
+interface ErrorResponse {
+  error: string;
+}
+
+export async function POST(
+  request: NextRequest
+): Promise<NextResponse<SearchResponse | ErrorResponse>> {
+  try {
+    const body = await request.json();
+    const query = body.query;
+
+    if (!query || typeof query !== 'string' || query.trim().length === 0) {
+      return NextResponse.json(
+        { error: 'query is required' },
+        { status: 400 }
+      );
+    }
+
+    const items = await searchPapers(query.trim());
+
+    return NextResponse.json({ items });
+  } catch (error) {
+    console.error('Error in search:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/web/src/app/search/page.tsx
+++ b/web/src/app/search/page.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import React, { useState, useCallback } from 'react';
+import { Search } from 'lucide-react';
+import type { MinimalPaperItem } from '../../types/paper';
+import { fetchPaperSummary, PaperSummaryResponse } from '../../services/api';
+import PaperCard from '../../components/PaperCard';
+
+export default function SearchPage() {
+  const [query, setQuery] = useState('');
+  const [papers, setPapers] = useState<MinimalPaperItem[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasSearched, setHasSearched] = useState(false);
+
+  const [expandedPaperIds, setExpandedPaperIds] = useState<Set<string>>(new Set());
+  const [paperSummaries, setPaperSummaries] = useState<Map<string, PaperSummaryResponse>>(new Map());
+  const [loadingSummaries, setLoadingSummaries] = useState<Set<string>>(new Set());
+
+  async function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    const q = query.trim();
+    if (!q) return;
+
+    setIsSearching(true);
+    setError(null);
+    setHasSearched(true);
+    setExpandedPaperIds(new Set());
+
+    try {
+      const res = await fetch('/api/papers/search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: q }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Search failed (${res.status})`);
+      }
+
+      const data = await res.json();
+      const items = (data.items ?? []) as MinimalPaperItem[];
+      setPapers(items);
+
+      // Preload summaries for all results
+      for (const paper of items) {
+        if (!paperSummaries.has(paper.paperUuid)) {
+          loadPaperSummary(paper.paperUuid);
+        }
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setIsSearching(false);
+    }
+  }
+
+  const loadPaperSummary = async (paperUuid: string): Promise<void> => {
+    setLoadingSummaries(prev => new Set(prev).add(paperUuid));
+    try {
+      const summary = await fetchPaperSummary(paperUuid);
+      setPaperSummaries(prev => new Map(prev).set(paperUuid, summary));
+    } catch (e) {
+      console.error('Failed to load summary:', e);
+    } finally {
+      setLoadingSummaries(prev => {
+        const next = new Set(prev);
+        next.delete(paperUuid);
+        return next;
+      });
+    }
+  };
+
+  const toggleExpanded = useCallback((paperUuid: string): void => {
+    setExpandedPaperIds(prev => {
+      if (prev.has(paperUuid)) {
+        const next = new Set(prev);
+        next.delete(paperUuid);
+        return next;
+      }
+      // Collapse previous, expand new
+      return new Set([paperUuid]);
+    });
+
+    if (!paperSummaries.has(paperUuid) && !loadingSummaries.has(paperUuid)) {
+      loadPaperSummary(paperUuid);
+    }
+  }, [paperSummaries, loadingSummaries]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <main className="w-full">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        <h1 className="text-3xl font-bold mb-2">Search Papers</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+          Describe topics you&apos;re interested in to find relevant papers.
+        </p>
+
+        <form onSubmit={handleSearch} className="flex gap-2 mb-8">
+          <input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="e.g., transformer architectures for computer vision"
+            className="flex-1 px-3 py-2 rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <button
+            type="submit"
+            disabled={isSearching || !query.trim()}
+            className="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            <Search size={16} />
+            Search
+          </button>
+        </form>
+
+        {error && (
+          <div className="mb-4 p-3 rounded-md border border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/40 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        {isSearching ? (
+          <div className="text-gray-600 dark:text-gray-300">Searching…</div>
+        ) : hasSearched && papers.length === 0 ? (
+          <div className="text-gray-600 dark:text-gray-300">No papers found. Try a different description.</div>
+        ) : papers.length > 0 ? (
+          <div className="space-y-4">
+            {papers.map((paper) => (
+              <PaperCard
+                key={paper.paperUuid}
+                paper={paper}
+                isExpanded={expandedPaperIds.has(paper.paperUuid)}
+                isLoadingSummary={loadingSummaries.has(paper.paperUuid)}
+                summary={paperSummaries.get(paper.paperUuid)}
+                onToggleExpand={toggleExpanded}
+                onLoadSummary={loadPaperSummary}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/web/src/components/NavBar.tsx
+++ b/web/src/components/NavBar.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import React, { useState } from 'react';
-import { Github, User as UserIcon, X, Menu } from 'lucide-react';
+import { Github, Search, User as UserIcon, X, Menu } from 'lucide-react';
 import { useSession } from '@/services/auth';
 import ThemeToggle from './ThemeToggle';
 
@@ -55,6 +55,12 @@ export default function NavBar({ className = '' }: NavBarProps) {
           <li>
             <Link href="/" className="text-sm text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">
               Papers Feed
+            </Link>
+          </li>
+          <li>
+            <Link href="/search" className="text-sm text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors flex items-center gap-1">
+              <Search size={14} />
+              Search
             </Link>
           </li>
           {/*<li>
@@ -134,6 +140,14 @@ export default function NavBar({ className = '' }: NavBarProps) {
                 className="block py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
               >
                 Papers Feed
+              </Link>
+              <Link
+                href="/search"
+                onClick={closeMobileMenu}
+                className="flex items-center justify-center gap-2 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
+              >
+                <Search size={16} />
+                <span>Search</span>
               </Link>
               <Link
                 href="https://github.com/ArthurDevel/papersummarizertool"

--- a/web/src/services/feed.service.ts
+++ b/web/src/services/feed.service.ts
@@ -501,7 +501,7 @@ function computePopularityScore(
  * @param paperUuids - Array of paper UUIDs to look up slugs for
  * @returns Map from paper_uuid to slug string
  */
-async function fetchSlugMap(paperUuids: string[]): Promise<Map<string, string>> {
+export async function fetchSlugMap(paperUuids: string[]): Promise<Map<string, string>> {
   if (paperUuids.length === 0) return new Map();
 
   const supabase = await createClient();

--- a/web/src/services/search.service.ts
+++ b/web/src/services/search.service.ts
@@ -1,0 +1,161 @@
+/**
+ * Search Service
+ *
+ * Server-side semantic search using OpenRouter embeddings and pgvector.
+ * Converts a user's text query into a vector embedding, then queries
+ * the match_papers_by_embedding RPC for similar papers.
+ */
+
+import { createClient } from '@/lib/supabase/server';
+import { getPaperThumbnailUrls } from '@/lib/supabase/storage';
+import { fetchSlugMap } from '@/services/feed.service';
+import type { MinimalPaper } from '@/types/paper';
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
+const OPENROUTER_EMBEDDINGS_URL = 'https://openrouter.ai/api/v1/embeddings';
+const EMBEDDING_MODEL = 'openai/text-embedding-3-small';
+const DEFAULT_MATCH_COUNT = 20;
+
+/** Scoring weights (same as feed.service.ts) */
+const SIMILARITY_WEIGHT = 0.5;
+const POPULARITY_WEIGHT = 0.3;
+const RECENCY_WEIGHT = 0.2;
+const RECENCY_HALF_LIFE_DAYS = 7;
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+/**
+ * Search papers by semantic similarity to a text query.
+ * @param query - User's search text (topic description)
+ * @param matchCount - Max results to return (default 20)
+ * @returns Array of MinimalPaper sorted by similarity
+ */
+export async function searchPapers(
+  query: string,
+  matchCount: number = DEFAULT_MATCH_COUNT
+): Promise<MinimalPaper[]> {
+  const embedding = await generateQueryEmbedding(query);
+  const vectorString = `[${embedding.join(',')}]`;
+
+  const supabase = await createClient();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase.rpc as any)(
+    'match_papers_by_embedding',
+    {
+      query_embedding: vectorString,
+      match_count: matchCount,
+      exclude_uuids: [],
+    }
+  );
+
+  if (error) {
+    throw new Error(`match_papers_by_embedding RPC failed: ${error.message}`);
+  }
+
+  const rows = (data ?? []) as {
+    paper_uuid: string;
+    title: string | null;
+    authors: string | null;
+    finished_at: string | null;
+    external_popularity_signals: Record<string, unknown> | null;
+    similarity: number;
+  }[];
+
+  if (rows.length === 0) return [];
+
+  // Score with weighted blend of similarity, popularity, and recency
+  const now = Date.now();
+  const scored = rows.map((row) => {
+    const recencyScore = row.finished_at
+      ? Math.exp(-(now - new Date(row.finished_at).getTime()) / (1000 * 60 * 60 * 24) * Math.LN2 / RECENCY_HALF_LIFE_DAYS)
+      : 0;
+    const popularityScore = computePopularityScore(row.external_popularity_signals);
+    const score =
+      SIMILARITY_WEIGHT * row.similarity +
+      POPULARITY_WEIGHT * popularityScore +
+      RECENCY_WEIGHT * recencyScore;
+    return { row, score };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+
+  const paperUuids = scored.map((s) => s.row.paper_uuid);
+  const [slugMap, thumbnailMap] = await Promise.all([
+    fetchSlugMap(paperUuids),
+    getPaperThumbnailUrls(paperUuids),
+  ]);
+
+  return scored.map(({ row }) => ({
+    paperUuid: row.paper_uuid,
+    title: row.title,
+    authors: row.authors,
+    slug: slugMap.get(row.paper_uuid) ?? null,
+    thumbnailUrl: thumbnailMap.get(row.paper_uuid) ?? null,
+  }));
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Computes a popularity score from external_popularity_signals.
+ * Same logic as feed.service.ts.
+ */
+function computePopularityScore(
+  signals: Record<string, unknown> | null
+): number {
+  if (!signals) return 0.5;
+
+  let parsed = signals;
+  if (typeof signals === 'string') {
+    try {
+      parsed = JSON.parse(signals);
+    } catch {
+      return 0.5;
+    }
+  }
+
+  const hfUpvotes = (parsed as Record<string, unknown>)?.upvotes;
+  if (typeof hfUpvotes === 'number') {
+    return Math.min(hfUpvotes / 100, 1.0);
+  }
+
+  return 0.5;
+}
+
+/**
+ * Generate a 1536-dim embedding for a text query via OpenRouter.
+ */
+async function generateQueryEmbedding(text: string): Promise<number[]> {
+  if (!OPENROUTER_API_KEY) {
+    throw new Error('OPENROUTER_API_KEY is not set');
+  }
+
+  const response = await fetch(OPENROUTER_EMBEDDINGS_URL, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${OPENROUTER_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: EMBEDDING_MODEL,
+      input: text,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`OpenRouter embeddings API error (${response.status}): ${body}`);
+  }
+
+  const result = await response.json();
+  return result.data[0].embedding as number[];
+}


### PR DESCRIPTION
Implements semantic search feature allowing users to find papers by describing topics of interest. Adds /search page with expandable feed UI, semantic search via OpenRouter embeddings (same model as worker), and ranked results using combined similarity, popularity, and recency scoring. Fixes match_papers_by_embedding RPC function to remove references to dropped thumbnail_data_url column and correct type mismatches.