### PR TITLE
Fix PostgreSQL RAND() syntax error

### DIFF
--- a/worker/dags/paper_processing_worker_dag.py
+++ b/worker/dags/paper_processing_worker_dag.py
@@ -251,7 +251,7 @@ def _claim_next_job(session: Session) -> Optional[JobInfo]:
             """
             SELECT id FROM papers
             WHERE status = 'not_started'
-            ORDER BY RAND()
+            ORDER BY RANDOM()
             LIMIT 1
             FOR UPDATE SKIP LOCKED
             """


### PR DESCRIPTION
Fix job claim query to use PostgreSQL's RANDOM() function instead of MySQL's RAND(). The paper_processing_worker DAG was failing when claiming available jobs because it used RAND() which doesn't exist in PostgreSQL.