### PR TITLE
Reduce paper processing parallelism to prevent OOM

### DIFF
--- a/worker/dags/paper_processing_worker_dag.py
+++ b/worker/dags/paper_processing_worker_dag.py
@@ -29,8 +29,8 @@ from users.client import set_requests_processed
 # ============================================================================
 
 MAX_PDF_PAGES = 70
-MAX_PAPERS_PER_RUN = 10
-MAX_PARALLEL_TASKS = 10
+MAX_PAPERS_PER_RUN = 50
+MAX_PARALLEL_TASKS = 2
 
 
 # ============================================================================


### PR DESCRIPTION
Reduced MAX_PARALLEL_TASKS from 10 to 2 and increased MAX_PAPERS_PER_RUN from 10 to 50 to handle bulk ingestion of 1000 papers. Processing 10 papers in parallel caused server OOM due to accumulated PDF bytes and page image buffers. With 2 parallel tasks, memory usage stays bounded while maintaining throughput (~10 days to process 1000 papers at twice-daily runs).