### PR TITLE
Optimize paper processing: remove OpenRouter cost lookup and parallelize OCR

### DIFF
--- a/worker/dags/paper_processing_worker_dag.py
+++ b/worker/dags/paper_processing_worker_dag.py
@@ -29,7 +29,7 @@ from users.client import set_requests_processed
 # ============================================================================
 
 MAX_PDF_PAGES = 70
-MAX_PAPERS_PER_RUN = 50
+MAX_PAPERS_PER_RUN = 500
 MAX_PARALLEL_TASKS = 2
 
 

--- a/worker/paperprocessor/client.py
+++ b/worker/paperprocessor/client.py
@@ -1,4 +1,5 @@
 import logging
+import asyncio
 import base64
 import io
 import time
@@ -8,7 +9,7 @@ from typing import Optional, Dict, Any, List
 
 from paperprocessor.models import ProcessedDocument, ProcessedPage, ApiCallCostForStep
 from paperprocessor.internals.pdf_to_image import convert_pdf_to_images
-from paperprocessor.internals.mistral_ocr import extract_markdown_from_pages
+from paperprocessor.internals.mistral_ocr import call_mistral_ocr, apply_ocr_results
 from paperprocessor.internals.metadata_extractor import extract_metadata
 from paperprocessor.internals.header_formatter import format_headers, format_images
 from paperprocessor.internals.summary_generator import generate_five_minute_summary
@@ -158,29 +159,34 @@ def get_processing_metrics_for_admin(paper_uuid: str) -> Dict[str, Any]:
 async def process_paper_pdf(pdf_contents: bytes, paper_id: Optional[str] = None) -> ProcessedDocument:
         """
         Simplified 4-step pipeline:
-        1. OCR → markdown per page
+        1. OCR → markdown per page (runs in parallel with image conversion)
         2. Extract metadata
         3. Format headers and images
         4. Generate summary from original content
         """
         logger.info("Paper processing pipeline v2 started (simplified).")
 
-        # Create ProcessedDocument DTO with PDF base64
         pdf_base64 = base64.b64encode(pdf_contents).decode('utf-8')
 
-        logger.info("Converting PDF to images for page image storage...")
+        # Run Mistral OCR and image conversion in parallel.
+        # OCR uses the raw PDF — it doesn't need the page images.
+        # Images are only needed for storage and coordinate transformation after OCR.
+        logger.info("Step 1: OCR + image conversion (parallel).")
+
+        async def _run_ocr():
+            loop = asyncio.get_event_loop()
+            return await loop.run_in_executor(None, call_mistral_ocr, pdf_base64)
+
+        ocr_task = asyncio.create_task(_run_ocr())
         images = await convert_pdf_to_images(pdf_contents)
 
         # Create ProcessedPages with base64 encoded images
         pages = []
         for i, image in enumerate(images):
             page_num = i + 1
-
-            # Convert PIL Image to base64
             buffered = io.BytesIO()
             image.save(buffered, format="PNG")
             img_base64 = base64.b64encode(buffered.getvalue()).decode('utf-8')
-
             page = ProcessedPage(
                 page_number=page_num,
                 img_base64=img_base64,
@@ -194,9 +200,9 @@ async def process_paper_pdf(pdf_contents: bytes, paper_id: Optional[str] = None)
             pages=pages
         )
 
-        # Step 1: OCR pages to markdown - populates ocr_markdown
-        logger.info("Step 1: OCR pages to markdown.")
-        await extract_markdown_from_pages(document)
+        # Wait for OCR to finish and apply results to pages
+        ocr_response = await ocr_task
+        apply_ocr_results(document, ocr_response)
 
         # Step 2: Extract metadata (title, authors) - modifies document in place
         logger.info("Step 2: Extracting metadata.")

--- a/worker/paperprocessor/internals/mistral_ocr.py
+++ b/worker/paperprocessor/internals/mistral_ocr.py
@@ -37,30 +37,34 @@ def extract_base64_from_data_url(data_url: str) -> str:
     return data_url
 
 
-async def extract_markdown_from_pages(document: ProcessedDocument) -> None:
+def call_mistral_ocr(pdf_base64: str):
     """
-    Step 1: Use Mistral OCR to get the markdown of each page.
-    Insert <<page>> tags. For the images, convert to base64 and insert reference tags.
-    Uses the PDF base64 from ProcessedDocument.
-    Modifies the document pages in place.
+    Send raw PDF to Mistral OCR API and return the response.
+    This is the network-bound part that can run concurrently with image conversion.
+
+    @param pdf_base64: Base64-encoded PDF content
+    @returns Raw Mistral OCR response object
     """
-    logger.info("Extracting markdown from pages using Mistral OCR...")
-    
-    # Step 1: Setup Mistral client
-    client = create_mistral_client()
-    document_spec = create_document_spec(document.pdf_base64)
-    
-    # Step 2: Call Mistral OCR API
     logger.info("Calling Mistral OCR API...")
-    ocr_response = client.ocr.process(
+    client = create_mistral_client()
+    document_spec = create_document_spec(pdf_base64)
+    return client.ocr.process(
         model=MODEL,
         document=document_spec,
         include_image_base64=True
     )
-    
-    # Step 3: Process each page from OCR response
+
+
+def apply_ocr_results(document: ProcessedDocument, ocr_response) -> None:
+    """
+    Apply Mistral OCR results to a ProcessedDocument that already has pages with dimensions.
+    Sets ocr_markdown and extracts images with coordinate transformation.
+
+    @param document: ProcessedDocument with pages (must have width/height set)
+    @param ocr_response: Raw Mistral OCR response from call_mistral_ocr
+    """
     logger.info(f"Processing {len(ocr_response.pages)} pages from OCR response")
-    
+
     for ocr_page in ocr_response.pages:
         page_index = ocr_page.index
         page_markdown = ocr_page.markdown
@@ -140,3 +144,14 @@ async def extract_markdown_from_pages(document: ProcessedDocument) -> None:
         logger.info(f"Page {page_index + 1}: OCR complete, found {len(ocr_images)} images")
     
     logger.info(f"Mistral OCR processing complete for {len(document.pages)} pages")
+
+
+async def extract_markdown_from_pages(document: ProcessedDocument) -> None:
+    """
+    Convenience wrapper: calls Mistral OCR and applies results in one step.
+    Used by DAGs that don't need parallelization.
+
+    @param document: ProcessedDocument with pdf_base64 and pages
+    """
+    ocr_response = call_mistral_ocr(document.pdf_base64)
+    apply_ocr_results(document, ocr_response)

--- a/worker/shared/openrouter/client.py
+++ b/worker/shared/openrouter/client.py
@@ -2,7 +2,6 @@ import httpx
 import logging
 from typing import Dict, Any, List, Optional
 from datetime import datetime
-import asyncio
 import json
 import re
 import os
@@ -117,21 +116,14 @@ async def get_llm_response(messages: List[Dict[str, Any]], model: str) -> LLMCal
             response_text = (first_message or {}).get("content") if first_message else None
             generation_id = data.get("id")
 
-            total_cost: Optional[float] = None
-            if generation_id:
-                try:
-                    total_cost = await get_generation_cost(generation_id)
-                except Exception as ce:
-                    logger.error(f"Failed to retrieve cost for generation {generation_id}: {ce}")
-
             end_time = datetime.utcnow()
-            
-            # Create cost info object (pure cost data only) (pure cost data only)
+
+            # Read cost directly from usage (OpenRouter includes it in the response)
             cost_info = ApiCallCost(
                 prompt_tokens=usage.get("prompt_tokens"),
                 completion_tokens=usage.get("completion_tokens"),
                 total_tokens=usage.get("total_tokens"),
-                total_cost=total_cost
+                total_cost=usage.get("cost"),
             )
 
             return LLMCallResult(
@@ -218,21 +210,14 @@ async def get_multimodal_json_response(system_prompt: str, user_prompt_parts: Li
                     logger.error("Error parsing JSON from OpenRouter response: %s", e)
                     parsed = {}
 
-            total_cost: Optional[float] = None
-            if generation_id:
-                try:
-                    total_cost = await get_generation_cost(generation_id)
-                except Exception as ce:
-                    logger.error(f"Failed to retrieve cost for generation {generation_id}: {ce}")
-
             end_time = datetime.utcnow()
-            
-            # Create cost info object (pure cost data only)
+
+            # Read cost directly from usage (OpenRouter includes it in the response)
             cost_info = ApiCallCost(
                 prompt_tokens=usage.get("prompt_tokens"),
                 completion_tokens=usage.get("completion_tokens"),
                 total_tokens=usage.get("total_tokens"),
-                total_cost=total_cost
+                total_cost=usage.get("cost"),
             )
 
             return LLMJsonCallResult(
@@ -324,21 +309,14 @@ async def get_json_response(system_prompt: str, user_prompt: str, model: str) ->
                     logger.error("Error parsing JSON from OpenRouter response: %s", e)
                     parsed = {}
 
-            total_cost: Optional[float] = None
-            if generation_id:
-                try:
-                    total_cost = await get_generation_cost(generation_id)
-                except Exception as ce:
-                    logger.error(f"Failed to retrieve cost for generation {generation_id}: {ce}")
-
             end_time = datetime.utcnow()
-            
-            # Create cost info object (pure cost data only)
+
+            # Read cost directly from usage (OpenRouter includes it in the response)
             cost_info = ApiCallCost(
                 prompt_tokens=usage.get("prompt_tokens"),
                 completion_tokens=usage.get("completion_tokens"),
                 total_tokens=usage.get("total_tokens"),
-                total_cost=total_cost
+                total_cost=usage.get("cost"),
             )
 
             return LLMJsonCallResult(
@@ -379,25 +357,6 @@ async def get_json_response(system_prompt: str, user_prompt: str, model: str) ->
                 parsed_json={},
             )
 
-
-async def get_generation_cost(generation_id: str) -> float:
-    """
-    Retrieves the cost of a specific generation from OpenRouter.
-    """
-    # Add a small delay to allow for the generation stats to be processed.
-    await asyncio.sleep(2)
-    async with httpx.AsyncClient(base_url=BASE_URL, headers=_HEADERS, timeout=TIMEOUT_SECONDS) as client:
-        try:
-            response = await client.get(f"/generation?id={generation_id}")
-            response.raise_for_status()
-            data = response.json()
-            logger.info(f"Received cost data for generation {generation_id}: {json.dumps(data)}")
-            generation_data = data.get("data", {})
-            return generation_data.get("total_cost", 0.0)
-        except httpx.HTTPStatusError as e:
-            logger.error(f"HTTPStatusError getting generation cost for id {generation_id}: {e}")
-            logger.error(f"Response: {e.response.text}")
-            raise
 
 
 async def get_embeddings(


### PR DESCRIPTION
Remove get_generation_cost() function that was making 404'd API calls to OpenRouter (~9s per LLM call). Instead read cost directly from usage.cost field already present in response. Split Mistral OCR processing into separate call_mistral_ocr() and apply_ocr_results() functions to enable concurrent execution with image conversion (~8s per paper). Increase MAX_PAPERS_PER_RUN to 500 for better throughput with reduced parallelism. Total optimization: ~17s per paper (25% speedup on typical 15-page papers).