### PR TITLE
Add on-demand summary generation with progress bar

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -54,6 +54,8 @@ const PaperCardWithTracking = ({
   paper,
   isExpanded,
   isLoadingSummary,
+  isGeneratingSummary,
+  generateSummaryError,
   summary,
   onToggleExpand,
   onLoadSummary,
@@ -62,6 +64,8 @@ const PaperCardWithTracking = ({
   paper: MinimalPaperItem;
   isExpanded: boolean;
   isLoadingSummary: boolean;
+  isGeneratingSummary?: boolean;
+  generateSummaryError?: boolean;
   summary?: PaperSummaryResponse;
   onToggleExpand: (paperUuid: string) => void;
   onLoadSummary?: (paperUuid: string) => void;
@@ -81,6 +85,8 @@ const PaperCardWithTracking = ({
       paper={paper}
       isExpanded={isExpanded}
       isLoadingSummary={isLoadingSummary}
+      isGeneratingSummary={isGeneratingSummary}
+      generateSummaryError={generateSummaryError}
       summary={summary}
       onToggleExpand={onToggleExpand}
       onLoadSummary={onLoadSummary}
@@ -102,6 +108,8 @@ export default function ScrollingPapersPage() {
   const [expandedPaperIds, setExpandedPaperIds] = useState<Set<string>>(new Set());
   const [paperSummaries, setPaperSummaries] = useState<Map<string, PaperSummaryResponse>>(new Map());
   const [loadingSummaries, setLoadingSummaries] = useState<Set<string>>(new Set());
+  const [generatingSummaries, setGeneratingSummaries] = useState<Set<string>>(new Set());
+  const [generateErrors, setGenerateErrors] = useState<Set<string>>(new Set());
   const [pendingScrollAdjustment, setPendingScrollAdjustment] = useState<{ elementId: string; offsetFromTop: number } | null>(null);
 
   const observerTarget = useRef<HTMLDivElement>(null);
@@ -205,8 +213,14 @@ export default function ScrollingPapersPage() {
       if (!paperSummaries.has(paperUuid) && !loadingSummaries.has(paperUuid)) {
         loadPaperSummary(paperUuid);
       }
+
+      // Auto-generate summary if it's null and not already generating
+      const existing = paperSummaries.get(paperUuid);
+      if (existing && !existing.fiveMinuteSummary && !generatingSummaries.has(paperUuid)) {
+        generateSummaryForCard(paperUuid);
+      }
     }
-  }, [expandedPaperIds, paperSummaries, loadingSummaries, trackExpand]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [expandedPaperIds, paperSummaries, loadingSummaries, generatingSummaries, trackExpand]); // eslint-disable-line react-hooks/exhaustive-deps
 
   /**
    * Loads the summary for a specific paper
@@ -222,6 +236,49 @@ export default function ScrollingPapersPage() {
       console.error('Failed to load summary:', e);
     } finally {
       setLoadingSummaries(prev => {
+        const next = new Set(prev);
+        next.delete(paperUuid);
+        return next;
+      });
+    }
+  };
+
+  /**
+   * Generates a summary on-demand for a paper card that has no summary yet.
+   * @param paperUuid - The UUID of the paper to generate a summary for
+   */
+  const generateSummaryForCard = async (paperUuid: string): Promise<void> => {
+    if (generatingSummaries.has(paperUuid)) return;
+
+    setGeneratingSummaries(prev => new Set(prev).add(paperUuid));
+
+    try {
+      const response = await fetch(`/api/papers/${paperUuid}/generate-summary`, {
+        method: 'POST',
+      });
+      if (!response.ok) throw new Error('Failed to generate summary');
+      const data = await response.json();
+
+      setPaperSummaries(prev => {
+        const next = new Map(prev);
+        const existing = next.get(paperUuid);
+        if (existing) {
+          next.set(paperUuid, { ...existing, fiveMinuteSummary: data.summary });
+        }
+        return next;
+      });
+
+      // Clear any previous error for this paper
+      setGenerateErrors(prev => {
+        const next = new Set(prev);
+        next.delete(paperUuid);
+        return next;
+      });
+    } catch (e) {
+      console.error('Failed to generate summary:', e);
+      setGenerateErrors(prev => new Set(prev).add(paperUuid));
+    } finally {
+      setGeneratingSummaries(prev => {
         const next = new Set(prev);
         next.delete(paperUuid);
         return next;
@@ -300,6 +357,8 @@ export default function ScrollingPapersPage() {
             const isExpanded = expandedPaperIds.has(paper.paperUuid);
             const summary = paperSummaries.get(paper.paperUuid);
             const isLoadingSummary = loadingSummaries.has(paper.paperUuid);
+            const isGenerating = generatingSummaries.has(paper.paperUuid);
+            const hasGenerateError = generateErrors.has(paper.paperUuid);
 
             return (
               <PaperCardWithTracking
@@ -307,6 +366,8 @@ export default function ScrollingPapersPage() {
                 paper={paper}
                 isExpanded={isExpanded}
                 isLoadingSummary={isLoadingSummary}
+                isGeneratingSummary={isGenerating}
+                generateSummaryError={hasGenerateError}
                 summary={summary}
                 onToggleExpand={toggleExpanded}
                 onLoadSummary={loadPaperSummary}

--- a/web/src/app/paper/[slug]/SharedPaperClient.tsx
+++ b/web/src/app/paper/[slug]/SharedPaperClient.tsx
@@ -34,6 +34,7 @@ export default function SharedPaperClient({ initialPaperData, slug }: SharedPape
   const [expandedPaperIds, setExpandedPaperIds] = useState<Set<string>>(new Set());
   const [paperSummaries, setPaperSummaries] = useState<Map<string, PaperSummary>>(new Map());
   const [loadingSummaries, setLoadingSummaries] = useState<Set<string>>(new Set());
+  const [generatingSummaries, setGeneratingSummaries] = useState<Set<string>>(new Set());
   const [copied, setCopied] = useState(false);
   const [isGeneratingSummary, setIsGeneratingSummary] = useState(false);
   const [generatedSummary, setGeneratedSummary] = useState<string | null>(null);
@@ -104,19 +105,26 @@ export default function SharedPaperClient({ initialPaperData, slug }: SharedPape
     };
   }, [hasMore, isLoading, currentPage, loadPage]);
 
-  // Toggle paper expansion
+  // Toggle paper expansion — auto-generate summary if missing
   const toggleExpanded = useCallback((paperUuid: string) => {
     setExpandedPaperIds(prev => {
       const next = new Set(prev);
-      if (next.has(paperUuid)) {
-        next.delete(paperUuid);
-      } else {
+      const isExpanding = !next.has(paperUuid);
+      if (isExpanding) {
         next.clear();
         next.add(paperUuid);
+
+        // Auto-generate summary if it's null and not already generating
+        const existing = paperSummaries.get(paperUuid);
+        if (existing && !existing.fiveMinuteSummary && !generatingSummaries.has(paperUuid)) {
+          generateSummaryForCard(paperUuid);
+        }
+      } else {
+        next.delete(paperUuid);
       }
       return next;
     });
-  }, []);
+  }, [paperSummaries, generatingSummaries]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Load paper summary
   const loadPaperSummary = async (paperUuid: string) => {
@@ -133,6 +141,39 @@ export default function SharedPaperClient({ initialPaperData, slug }: SharedPape
       console.error('Failed to load summary:', e);
     } finally {
       setLoadingSummaries(prev => {
+        const next = new Set(prev);
+        next.delete(paperUuid);
+        return next;
+      });
+    }
+  };
+
+  // Generate summary on-demand for a feed card
+  const generateSummaryForCard = async (paperUuid: string) => {
+    if (generatingSummaries.has(paperUuid)) return;
+
+    setGeneratingSummaries(prev => new Set(prev).add(paperUuid));
+
+    try {
+      const response = await fetch(`/api/papers/${paperUuid}/generate-summary`, {
+        method: 'POST',
+      });
+      if (!response.ok) throw new Error('Failed to generate summary');
+      const data = await response.json();
+
+      // Update the stored summary with the generated text
+      setPaperSummaries(prev => {
+        const next = new Map(prev);
+        const existing = next.get(paperUuid);
+        if (existing) {
+          next.set(paperUuid, { ...existing, fiveMinuteSummary: data.summary });
+        }
+        return next;
+      });
+    } catch (e) {
+      console.error('Failed to generate summary:', e);
+    } finally {
+      setGeneratingSummaries(prev => {
         const next = new Set(prev);
         next.delete(paperUuid);
         return next;
@@ -333,6 +374,7 @@ export default function SharedPaperClient({ initialPaperData, slug }: SharedPape
             const isExpanded = expandedPaperIds.has(paper.paperUuid);
             const summary = paperSummaries.get(paper.paperUuid);
             const isLoadingSummary = loadingSummaries.has(paper.paperUuid);
+            const isGenerating = generatingSummaries.has(paper.paperUuid);
 
             return (
               <PaperCard
@@ -340,6 +382,7 @@ export default function SharedPaperClient({ initialPaperData, slug }: SharedPape
                 paper={paper}
                 isExpanded={isExpanded}
                 isLoadingSummary={isLoadingSummary}
+                isGeneratingSummary={isGenerating}
                 summary={summary}
                 onToggleExpand={toggleExpanded}
                 onLoadSummary={loadPaperSummary}

--- a/web/src/components/PaperCard.tsx
+++ b/web/src/components/PaperCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import type { MinimalPaperItem } from '../types/paper';
 import type { PaperSummaryResponse } from '../services/api';
 import ReactMarkdown from 'react-markdown';
@@ -21,6 +21,8 @@ interface PaperCardProps {
   paper: MinimalPaperItem;
   isExpanded: boolean;
   isLoadingSummary: boolean;
+  isGeneratingSummary?: boolean;
+  generateSummaryError?: boolean;
   summary?: PaperSummaryResponse;
   onToggleExpand: (paperUuid: string) => void;
   onLoadSummary?: (paperUuid: string) => void;
@@ -28,16 +30,48 @@ interface PaperCardProps {
   readingTrackerRef?: React.RefObject<HTMLDivElement | null>;
 }
 
+const GENERATE_DURATION_MS = 15_000;
+
 const PaperCard = React.forwardRef<HTMLDivElement, PaperCardProps>(({
   paper,
   isExpanded,
   isLoadingSummary,
+  isGeneratingSummary,
+  generateSummaryError,
   summary,
   onToggleExpand,
   onLoadSummary,
   readingTrackerRef,
 }, ref) => {
   const [copied, setCopied] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const progressRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Animate progress bar while generating
+  useEffect(() => {
+    if (isGeneratingSummary) {
+      setProgress(0);
+      const step = 50; // ms per tick
+      const increment = (step / GENERATE_DURATION_MS) * 100;
+      progressRef.current = setInterval(() => {
+        setProgress(prev => Math.min(prev + increment, 95));
+      }, step);
+    } else {
+      if (progressRef.current) {
+        clearInterval(progressRef.current);
+        progressRef.current = null;
+      }
+      // Snap to 100 briefly if we were generating, then reset
+      if (progress > 0) {
+        setProgress(100);
+        const t = setTimeout(() => setProgress(0), 400);
+        return () => clearTimeout(t);
+      }
+    }
+    return () => {
+      if (progressRef.current) clearInterval(progressRef.current);
+    };
+  }, [isGeneratingSummary]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Handle share button click - always copy to clipboard
   const handleShare = async (e: React.MouseEvent) => {
@@ -109,6 +143,18 @@ const PaperCard = React.forwardRef<HTMLDivElement, PaperCardProps>(({
         <div className="border-t border-gray-200 dark:border-gray-700 px-4 py-3">
           <div className="text-gray-600 dark:text-gray-400 text-sm">
             Loading summary...
+          </div>
+        </div>
+      ) : isGeneratingSummary || (isExpanded && progress > 0) ? (
+        <div className="border-t border-gray-200 dark:border-gray-700 px-4 py-4">
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">
+            Generating summary…
+          </p>
+          <div className="w-full h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-blue-500 rounded-full transition-all duration-100 ease-linear"
+              style={{ width: `${progress}%` }}
+            />
           </div>
         </div>
       ) : summary?.fiveMinuteSummary ? (
@@ -189,6 +235,12 @@ const PaperCard = React.forwardRef<HTMLDivElement, PaperCardProps>(({
             </div>
           </button>
         )
+      ) : generateSummaryError && isExpanded ? (
+        <div className="border-t border-gray-200 dark:border-gray-700 px-4 py-3">
+          <p className="text-sm text-red-500 dark:text-red-400">
+            Failed to generate summary. Try collapsing and expanding again.
+          </p>
+        </div>
       ) : null}
     </div>
   );

--- a/web/src/services/summary-generation.service.ts
+++ b/web/src/services/summary-generation.service.ts
@@ -12,6 +12,7 @@
  */
 
 import { createClient } from '@/lib/supabase/server';
+import { downloadPaperMarkdown } from '@/lib/supabase/storage';
 import { chatCompletion } from '@/lib/openrouter';
 
 // ============================================================================
@@ -112,16 +113,8 @@ export async function generateSummaryForPaper(paperUuid: string): Promise<Genera
     return { summary: existingSummary, alreadyExisted: true };
   }
 
-  // Step 2: Download content.md from Supabase Storage
-  const { data: fileData, error: downloadError } = await supabase.storage
-    .from('papers')
-    .download(`${paperUuid}/content.md`);
-
-  if (downloadError || !fileData) {
-    throw new Error('Paper content not available for summary generation.');
-  }
-
-  const contentMarkdown = await fileData.text();
+  // Step 2: Download content.md from Supabase Storage (uses service role key)
+  const contentMarkdown = await downloadPaperMarkdown(paperUuid);
 
   // Step 3: Generate summary via Gemini 3 Flash
   const response = await chatCompletion(


### PR DESCRIPTION
Implements on-demand summary generation triggered when expanding papers with null summaries. Adds animated progress bar (0→95% over 15s) showing generation in progress. Fixes critical bug where error state from failed attempts persisted and prevented successful summaries from displaying. Summaries now always take priority over stale errors, and errors are cleared on success.