### PR TITLE
Fix summary flash when expanding paper with existing summary

### DIFF
--- a/web/src/components/PaperCard.tsx
+++ b/web/src/components/PaperCard.tsx
@@ -139,7 +139,7 @@ const PaperCard = React.forwardRef<HTMLDivElement, PaperCardProps>(({
       </button>
 
       {/* Summary Preview or Expanded Content */}
-      {isLoadingSummary || isGeneratingSummary || (isExpanded && progress > 0) ? (
+      {!summary?.fiveMinuteSummary && (isLoadingSummary || isGeneratingSummary || (isExpanded && progress > 0)) ? (
         <div className="border-t border-gray-200 dark:border-gray-700 px-4 py-4">
           {summary?.abstractSummary && (
             <div className="mb-3">


### PR DESCRIPTION
When toggling open a paper that already has a five-minute summary, the component was briefly showing the abstract summary before rendering the full summary. This was caused by the loading/generating UI branch taking precedence over the summary display branch. The fix adds a check to skip the loading UI when the five-minute summary is already available.