### PR TITLE
Backfill newest papers first in author stats DAG

### DIFF
--- a/worker/dags/backfill_author_stats_dag.py
+++ b/worker/dags/backfill_author_stats_dag.py
@@ -80,7 +80,7 @@ def fetch_papers_without_author_links(batch_size: int = BATCH_SIZE, exclude_ids:
         )
         if exclude_ids:
             query = query.filter(~PaperRecord.id.in_(exclude_ids))
-        rows = query.order_by(PaperRecord.id).limit(batch_size).all()
+        rows = query.order_by(PaperRecord.id.desc()).limit(batch_size).all()
 
         return [
             {"id": row.id, "paper_uuid": row.paper_uuid, "arxiv_id": row.arxiv_id}


### PR DESCRIPTION
## Summary
- Changed backfill_author_stats_dag to process papers in descending order (newest first) so recent papers get author h-index data populated before older ones.

## Test plan
- [ ] Run backfill_author_stats DAG and verify it picks up the most recent papers first

🤖 Generated with [Claude Code](https://claude.com/claude-code)