### PR TITLE
Make author linking and h-index computation mandatory

### DIFF
--- a/worker/dags/backfill_author_stats_dag.py
+++ b/worker/dags/backfill_author_stats_dag.py
@@ -88,6 +88,30 @@ def fetch_papers_without_author_links(batch_size: int = BATCH_SIZE, exclude_ids:
         ]
 
 
+def fetch_papers_missing_signals(batch_size: int = BATCH_SIZE) -> List[int]:
+    """
+    Query papers that have author links but are missing max_author_h_index in signals.
+    These are papers where linking succeeded but stats/signals weren't written yet.
+
+    @param batch_size: Maximum number of paper IDs to fetch
+    @returns List of paper IDs
+    """
+    from sqlalchemy import text
+
+    with database_session() as session:
+        rows = session.execute(text("""
+            SELECT DISTINCT pa.paper_id
+            FROM paper_authors pa
+            JOIN papers p ON p.id = pa.paper_id
+            WHERE p.signals IS NULL
+               OR NOT (p.signals ? 'max_author_h_index')
+            ORDER BY pa.paper_id DESC
+            LIMIT :limit
+        """), {"limit": batch_size}).fetchall()
+
+        return [row[0] for row in rows]
+
+
 def link_batch_authors(papers: List[Dict]) -> Dict[str, int]:
     """
     Batch-fetch author IDs from Semantic Scholar and create DB records.
@@ -359,6 +383,36 @@ def backfill_author_stats_dag():
             # Step 3: Update signals for papers in this batch
             print(f"  Updating signals for {len(batch_paper_ids)} papers...")
             signals_result = update_paper_signals(only_paper_ids=batch_paper_ids)
+            total_signals_updated += signals_result["updated"]
+            total_signals_failed += signals_result["failed"]
+            print(f"  Signals: {signals_result['updated']} updated, {signals_result['failed']} failed")
+
+        # Catch-up pass: papers that have author links but missing signals
+        # (e.g. from a previous run that crashed after linking but before stats/signals)
+        missing = fetch_papers_missing_signals(batch_size=BATCH_SIZE)
+        if missing:
+            print(f"\n{'=' * 50}")
+            print(f"CATCH-UP: {len(missing)} papers with authors but missing signals")
+            print(f"{'=' * 50}")
+
+            # Collect all author IDs for these papers
+            with database_session() as session:
+                author_rows = session.query(
+                    PaperAuthorRecord.author_id
+                ).filter(
+                    PaperAuthorRecord.paper_id.in_(missing)
+                ).distinct().all()
+                catchup_author_ids = {row.author_id for row in author_rows}
+
+            if catchup_author_ids:
+                print(f"  Refreshing stats for {len(catchup_author_ids)} authors...")
+                stats_result = refresh_author_stats(stale_days=STALE_DAYS, only_author_ids=catchup_author_ids)
+                total_stats_refreshed += stats_result["refreshed"]
+                total_stats_failed += stats_result["failed"]
+                print(f"  Stats: {stats_result['refreshed']} refreshed, {stats_result['failed']} failed")
+
+            print(f"  Updating signals for {len(missing)} papers...")
+            signals_result = update_paper_signals(only_paper_ids=set(missing))
             total_signals_updated += signals_result["updated"]
             total_signals_failed += signals_result["failed"]
             print(f"  Signals: {signals_result['updated']} updated, {signals_result['failed']} failed")

--- a/worker/dags/paper_processing_worker_dag.py
+++ b/worker/dags/paper_processing_worker_dag.py
@@ -111,23 +111,81 @@ def database_session():
 # ============================================================================
 
 
+def _refresh_and_score_paper(paper_id: int, author_ids: set) -> None:
+    """
+    Fetch stats for the paper's authors from Semantic Scholar and write
+    max_author_h_index into signals. Raises on failure so the paper is
+    marked as failed.
+
+    @param paper_id: Database ID of the paper
+    @param author_ids: Set of author DB IDs to refresh
+    """
+    from shared.semantic_scholar.client import fetch_author_stats
+    from sqlalchemy import func
+
+    if not author_ids:
+        raise Exception(f"No authors found for paper {paper_id}, cannot compute h-index")
+
+    # Refresh stats for authors that don't have them yet
+    with database_session() as session:
+        stale_authors = session.query(AuthorRecord).filter(
+            AuthorRecord.id.in_(author_ids),
+            AuthorRecord.stats_updated_at.is_(None),
+        ).all()
+        to_refresh = [(a.id, a.s2_author_id) for a in stale_authors]
+
+    for author_db_id, s2_id in to_refresh:
+        stats = fetch_author_stats(s2_id)
+        with database_session() as session:
+            record = session.query(AuthorRecord).filter(
+                AuthorRecord.id == author_db_id
+            ).first()
+            if record:
+                record.name = stats.name
+                record.affiliations = stats.affiliations
+                record.homepage = stats.homepage
+                record.paper_count = stats.paper_count
+                record.citation_count = stats.citation_count
+                record.h_index = stats.h_index
+                record.stats_updated_at = datetime.utcnow()
+
+    # Compute and write max_author_h_index
+    with database_session() as session:
+        row = session.query(
+            func.max(AuthorRecord.h_index).label("max_h_index"),
+        ).join(
+            PaperAuthorRecord, PaperAuthorRecord.author_id == AuthorRecord.id
+        ).filter(
+            PaperAuthorRecord.paper_id == paper_id,
+            AuthorRecord.h_index.isnot(None),
+        ).first()
+
+        if not row or row.max_h_index is None:
+            raise Exception(f"Could not compute max_author_h_index for paper {paper_id}")
+
+        paper = session.query(PaperRecord).filter(
+            PaperRecord.id == paper_id
+        ).first()
+        if paper:
+            existing_signals = paper.signals or {}
+            existing_signals["max_author_h_index"] = row.max_h_index
+            paper.signals = existing_signals
+            print(f"  Set max_author_h_index={row.max_h_index} for paper {paper_id}")
+
+
 def _link_authors_for_paper(arxiv_id: str) -> None:
     """
     Link authors from Semantic Scholar for a single arXiv paper.
-    Best-effort: logs errors but does not raise.
+    Raises on failure so the paper is marked as failed.
 
     @param arxiv_id: arXiv identifier to look up in S2
     """
     from shared.semantic_scholar.client import fetch_paper_authors
 
-    try:
-        s2_result = fetch_paper_authors(arxiv_id)
-    except Exception as e:
-        print(f"  S2 author lookup failed for {arxiv_id}: {e}")
-        return
+    s2_result = fetch_paper_authors(arxiv_id)
 
     if not s2_result.authors:
-        return
+        raise Exception(f"No authors returned from Semantic Scholar for {arxiv_id}")
 
     with database_session() as session:
         record = session.query(PaperRecord).filter(
@@ -172,6 +230,9 @@ def _link_authors_for_paper(arxiv_id: str) -> None:
                 authors_linked += 1
 
         print(f"  Linked {authors_linked} authors for {arxiv_id}")
+
+        # Fetch stats and compute max_author_h_index signal
+        _refresh_and_score_paper(record.id, seen_author_ids)
 
 
 # ============================================================================
@@ -361,7 +422,7 @@ async def _process_paper_job_complete(job: JobInfo) -> None:
             session.flush()  # Ensure slug is committed before marking requests
             await set_requests_processed(session, saved_paper.arxiv_id, paper_slug_dto.slug)
         
-        # Step 3: Link authors via Semantic Scholar (best-effort, non-blocking)
+        # Step 3: Link authors and compute h-index signal
         if job.arxiv_id:
             _link_authors_for_paper(job.arxiv_id)
 


### PR DESCRIPTION
Paper processing now requires successful author linking and h-index computation; papers fail if Semantic Scholar lookup fails or h-index cannot be computed. Backfill DAG now has a catch-up pass that re-processes papers with author links but missing max_author_h_index in signals. Both DAGs process per-batch instead of waiting for all papers to complete.