### PR TITLE
Reformat ranking badge with label and right alignment

### DIFF
--- a/web/src/components/PaperCard.tsx
+++ b/web/src/components/PaperCard.tsx
@@ -163,14 +163,12 @@ const PaperCard = React.forwardRef<HTMLDivElement, PaperCardProps>(({
         isExpanded ? (
           // Fully expanded
           <div className="border-t border-gray-200 dark:border-gray-700 p-4 bg-gray-50 dark:bg-gray-900/50 relative">
-            <div className="mb-3 flex items-center gap-2">
-              <span className="inline-block px-2 py-0.5 text-xs font-medium rounded bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300">
-                5-Minute Summary
-              </span>
-              {paper.scoreBreakdown && (
-                <ScoreBreakdownBadge breakdown={paper.scoreBreakdown} />
-              )}
-              {summary.arxivUrl && (
+            <div className="mb-3 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="inline-block px-2 py-0.5 text-xs font-medium rounded bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300">
+                  5-Minute Summary
+                </span>
+                {summary.arxivUrl && (
                 <a
                   href={summary.arxivUrl}
                   target="_blank"
@@ -183,6 +181,10 @@ const PaperCard = React.forwardRef<HTMLDivElement, PaperCardProps>(({
                   </svg>
                   arXiv
                 </a>
+              )}
+              </div>
+              {paper.scoreBreakdown && (
+                <ScoreBreakdownBadge breakdown={paper.scoreBreakdown} />
               )}
             </div>
             <div ref={readingTrackerRef} className="prose prose-sm dark:prose-invert max-w-none">

--- a/web/src/components/ScoreBreakdownBadge.tsx
+++ b/web/src/components/ScoreBreakdownBadge.tsx
@@ -271,7 +271,7 @@ export default function ScoreBreakdownBadge({ breakdown }: { breakdown: ScoreBre
         {breakdown.isExploration ? (
           <span className="text-purple-600 dark:text-purple-400">explore</span>
         ) : (
-          <span>{breakdown.score.toFixed(2)}</span>
+          <span>Ranking ({breakdown.score.toFixed(2)})</span>
         )}
       </button>
 


### PR DESCRIPTION
## What
Modified the score breakdown badge on expanded paper cards to display as 'Ranking (score)' instead of just the raw score number. Restructured the badge row layout so the ranking badge appears right-aligned next to the arXiv link, while the 5-Minute Summary badge stays left-aligned.

## Why
The bare score number (e.g. '0.85') was unclear to users. The 'Ranking' label makes it immediately obvious what the score represents. Right-aligning the badge creates visual balance in the expanded card.

## How
- Modified PaperCard.tsx: Split the badge container into two groups using flexbox justify-between (left: 5-Minute Summary + arXiv; right: Ranking badge)
- Modified ScoreBreakdownBadge.tsx: Changed badge text from score value to 'Ranking (value)' format

## How to test
Open the home page, expand a paper card. In the expanded view, verify:
1. The ranking badge shows 'Ranking (0.XX)' format
2. The ranking badge is right-aligned
3. The 5-Minute Summary and arXiv badges remain left-aligned and grouped together