### PR TITLE
Optimize S2 API calls with batch endpoints and exponential backoff

### DIFF
--- a/worker/dags/backfill_author_stats_dag.py
+++ b/worker/dags/backfill_author_stats_dag.py
@@ -205,13 +205,14 @@ def link_batch_authors(papers: List[Dict]) -> Dict[str, int]:
 
 def refresh_author_stats(stale_days: int = STALE_DAYS, only_author_ids: set = None) -> Dict[str, int]:
     """
-    Fetch stats for authors where stats_updated_at is NULL or stale.
+    Batch-fetch stats for authors where stats_updated_at is NULL or stale.
+    Uses POST /author/batch (up to 1000 per request) instead of individual calls.
 
     @param stale_days: Number of days after which stats are considered stale
     @param only_author_ids: If provided, only refresh these author IDs
     @returns Dict with refreshed and failed counts
     """
-    from shared.semantic_scholar.client import fetch_author_stats
+    from shared.semantic_scholar.client import fetch_author_stats_batch
 
     cutoff = datetime.utcnow() - timedelta(days=stale_days)
     refreshed = 0
@@ -224,21 +225,33 @@ def refresh_author_stats(stale_days: int = STALE_DAYS, only_author_ids: set = No
         )
         if only_author_ids:
             query = query.filter(AuthorRecord.id.in_(only_author_ids))
-        stale_authors = query.limit(500).all()
+        stale_authors = query.limit(1000).all()
 
-        author_ids = [(a.id, a.s2_author_id) for a in stale_authors]
+        # Map s2_author_id -> db id for updating after batch fetch
+        s2_to_db = {a.s2_author_id: a.id for a in stale_authors}
 
-    print(f"  Found {len(author_ids)} authors needing stats refresh")
+    s2_ids = list(s2_to_db.keys())
+    print(f"  Found {len(s2_ids)} authors needing stats refresh")
 
-    for idx, (author_db_id, s2_id) in enumerate(author_ids):
-        if (idx + 1) % 50 == 0:
-            print(f"  Stats progress: {idx + 1}/{len(author_ids)} ({refreshed} refreshed, {failed} failed)")
+    if not s2_ids:
+        return {"refreshed": 0, "failed": 0}
 
+    try:
+        batch_results = fetch_author_stats_batch(s2_ids)
+    except Exception as e:
+        print(f"  Batch author stats fetch failed: {e}")
+        return {"refreshed": 0, "failed": len(s2_ids)}
+
+    print(f"  S2 returned stats for {len(batch_results)} authors")
+
+    for stats in batch_results:
+        db_id = s2_to_db.get(stats.s2_author_id)
+        if not db_id:
+            continue
         try:
-            stats = fetch_author_stats(s2_id)
             with database_session() as session:
                 record = session.query(AuthorRecord).filter(
-                    AuthorRecord.id == author_db_id
+                    AuthorRecord.id == db_id
                 ).first()
                 if record:
                     record.name = stats.name
@@ -250,8 +263,15 @@ def refresh_author_stats(stale_days: int = STALE_DAYS, only_author_ids: set = No
                     record.stats_updated_at = datetime.utcnow()
             refreshed += 1
         except Exception as e:
-            print(f"  FAIL author {s2_id}: {e}")
+            print(f"  FAIL saving author {stats.s2_author_id}: {e}")
             failed += 1
+
+    # Count authors that S2 didn't return (not found)
+    returned_ids = {s.s2_author_id for s in batch_results}
+    not_found = len(s2_ids) - len(returned_ids)
+    if not_found:
+        print(f"  {not_found} authors not found in S2")
+        failed += not_found
 
     return {"refreshed": refreshed, "failed": failed}
 

--- a/worker/dags/paper_processing_worker_dag.py
+++ b/worker/dags/paper_processing_worker_dag.py
@@ -120,7 +120,7 @@ def _refresh_and_score_paper(paper_id: int, author_ids: set) -> None:
     @param paper_id: Database ID of the paper
     @param author_ids: Set of author DB IDs to refresh
     """
-    from shared.semantic_scholar.client import fetch_author_stats
+    from shared.semantic_scholar.client import fetch_author_stats_batch
     from sqlalchemy import func
 
     if not author_ids:
@@ -132,22 +132,26 @@ def _refresh_and_score_paper(paper_id: int, author_ids: set) -> None:
             AuthorRecord.id.in_(author_ids),
             AuthorRecord.stats_updated_at.is_(None),
         ).all()
-        to_refresh = [(a.id, a.s2_author_id) for a in stale_authors]
+        s2_to_db = {a.s2_author_id: a.id for a in stale_authors}
 
-    for author_db_id, s2_id in to_refresh:
-        stats = fetch_author_stats(s2_id)
-        with database_session() as session:
-            record = session.query(AuthorRecord).filter(
-                AuthorRecord.id == author_db_id
-            ).first()
-            if record:
-                record.name = stats.name
-                record.affiliations = stats.affiliations
-                record.homepage = stats.homepage
-                record.paper_count = stats.paper_count
-                record.citation_count = stats.citation_count
-                record.h_index = stats.h_index
-                record.stats_updated_at = datetime.utcnow()
+    if s2_to_db:
+        batch_results = fetch_author_stats_batch(list(s2_to_db.keys()))
+        for stats in batch_results:
+            db_id = s2_to_db.get(stats.s2_author_id)
+            if not db_id:
+                continue
+            with database_session() as session:
+                record = session.query(AuthorRecord).filter(
+                    AuthorRecord.id == db_id
+                ).first()
+                if record:
+                    record.name = stats.name
+                    record.affiliations = stats.affiliations
+                    record.homepage = stats.homepage
+                    record.paper_count = stats.paper_count
+                    record.citation_count = stats.citation_count
+                    record.h_index = stats.h_index
+                    record.stats_updated_at = datetime.utcnow()
 
     # Compute and write max_author_h_index
     with database_session() as session:

--- a/worker/shared/semantic_scholar/client.py
+++ b/worker/shared/semantic_scholar/client.py
@@ -2,12 +2,14 @@
 Client for the Semantic Scholar API.
 
 Uses the free API with optional API key for higher rate limits.
-Free tier: 100 requests/5 minutes. With API key: 1 request/second.
+Free tier: 1000 req/s shared globally among all unauthenticated users.
+With API key: dedicated 1-10 req/s depending on endpoint.
 
 Responsibilities:
 - Fetch paper author data by arXiv ID
 - Fetch individual author stats (h-index, citations, etc.)
 - Batch fetch paper authors for bulk ingestion
+- Batch fetch author stats for bulk ingestion
 """
 
 import os
@@ -27,12 +29,12 @@ logger = logging.getLogger(__name__)
 
 S2_API_BASE = 'https://api.semanticscholar.org/graph/v1'
 
-# NOTE: The free-tier rate limit (100 req / 5 min) is shared globally across
-# ALL unauthenticated users, so adding a long delay between our requests
-# doesn't actually help — other users consume the budget too. Instead we
-# retry quickly (1s) on 429 until we get through.
-RETRY_DELAY = 1.0   # seconds between retries on 429
-MAX_RETRIES = 10     # enough attempts to ride out short contention windows
+# The free-tier rate limit is shared globally across ALL unauthenticated users.
+# Burst fast and retry with exponential backoff — waiting a fixed delay just
+# lets other users consume the pool. Tested in testscripts/7_test_rate_limits.py.
+RETRY_BASE_DELAY = 0.1  # seconds, doubles each retry
+RETRY_BACKOFF = 2.0
+MAX_RETRIES = 5
 
 # ============================================================================
 # HELPER FUNCTIONS
@@ -50,22 +52,23 @@ def _get_headers() -> dict:
 
 def _request_with_retry(method: str, url: str, **kwargs) -> requests.Response:
     """
-    Make an HTTP request with retry on 429 (rate limit) responses.
-    Retries every RETRY_DELAY seconds — the free-tier limit is shared
-    globally so there's no point backing off exponentially.
+    Make an HTTP request with exponential backoff retry on 429 responses.
+    Bursts fast and backs off — optimal for the shared global rate limit pool.
 
     @param method: HTTP method ('get' or 'post')
     @param url: Request URL
     @param kwargs: Additional arguments passed to requests.get/post
     @returns Response object
     """
+    delay = RETRY_BASE_DELAY
     for attempt in range(MAX_RETRIES):
         response = getattr(requests, method)(url, **kwargs)
         if response.status_code != 429:
             response.raise_for_status()
             return response
-        logger.warning(f"S2 rate limited (429), retrying in {RETRY_DELAY}s (attempt {attempt + 1}/{MAX_RETRIES})")
-        time.sleep(RETRY_DELAY)
+        logger.warning(f"S2 rate limited (429), retrying in {delay:.1f}s (attempt {attempt + 1}/{MAX_RETRIES})")
+        time.sleep(delay)
+        delay *= RETRY_BACKOFF
 
     # Final attempt, let it raise
     response = getattr(requests, method)(url, **kwargs)
@@ -130,6 +133,43 @@ def fetch_author_stats(s2_author_id: str) -> S2Author:
         citation_count=data.get('citationCount'),
         h_index=data.get('hIndex'),
     )
+
+
+def fetch_author_stats_batch(s2_author_ids: List[str]) -> List[S2Author]:
+    """
+    Batch fetch stats for multiple authors. Up to 1000 authors per request.
+
+    @param s2_author_ids: List of Semantic Scholar author IDs
+    @returns List of S2Author with stats (h_index, citation_count, etc.)
+    """
+    url = f'{S2_API_BASE}/author/batch'
+    params = {'fields': 'name,affiliations,homepage,paperCount,citationCount,hIndex'}
+
+    response = _request_with_retry(
+        'post', url,
+        headers=_get_headers(),
+        params=params,
+        json={'ids': s2_author_ids},
+        timeout=60,
+    )
+    results = response.json()
+
+    authors = []
+    for i, author_data in enumerate(results):
+        if author_data is None:
+            continue
+
+        authors.append(S2Author(
+            s2_author_id=s2_author_ids[i],
+            name=author_data.get('name', 'Unknown'),
+            affiliations=author_data.get('affiliations') or None,
+            homepage=author_data.get('homepage') or None,
+            paper_count=author_data.get('paperCount'),
+            citation_count=author_data.get('citationCount'),
+            h_index=author_data.get('hIndex'),
+        ))
+
+    return authors
 
 
 def fetch_paper_authors_batch(arxiv_ids: List[str]) -> List[S2PaperAuthors]:


### PR DESCRIPTION
Replaces individual author stat calls with batch endpoint (1 request for up to 1000 authors instead of 500+ calls). Switches retry from fixed 1s delay x 10 to exponential backoff (0.1s base, 2x factor, 5 retries) — bursting wins against the shared global rate limit pool. Backfill DAG batch size increased to 1000 to match batch endpoint capacity. Based on rate limit testing in testscripts/7_test_rate_limits.py.