### PR TITLE
Fix feed personalization: embeddings + RPC + UI

### DIFF
--- a/migrations/versions/20260312_000035_fix_match_rpc_return_types.py
+++ b/migrations/versions/20260312_000035_fix_match_rpc_return_types.py
@@ -1,0 +1,102 @@
+"""Fix match_papers_by_embedding RPC return type mismatch.
+
+The RETURNS TABLE declared types that don't match the actual column types:
+- paper_uuid: declared text, actual varchar(36)
+- title: declared text, actual varchar(512)
+- finished_at: declared timestamptz, actual timestamp (without tz)
+PostgreSQL refuses implicit casts inside RETURNS TABLE, causing the function
+to error on every call. Fix: cast mismatched columns in the SELECT.
+
+Revision ID: 20260312_000035
+Revises: 20260312_000034
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '20260312_000035'
+down_revision = '20260312_000034'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Recreate RPC with explicit text casts on varchar columns."""
+    connection = op.get_bind()
+
+    connection.execute(sa.text(
+        "DROP FUNCTION IF EXISTS match_papers_by_embedding(vector, int, text[])"
+    ))
+    connection.execute(sa.text("""
+        CREATE FUNCTION match_papers_by_embedding(
+            query_embedding vector(1536),
+            match_count int DEFAULT 20,
+            exclude_uuids text[] DEFAULT '{}'
+        )
+        RETURNS TABLE (
+            paper_uuid text,
+            title text,
+            authors text,
+            finished_at timestamptz,
+            embedding vector(1536),
+            signals jsonb,
+            similarity float
+        ) AS $$
+        BEGIN
+            RETURN QUERY
+            SELECT
+                p.paper_uuid::text, p.title::text, p.authors,
+                p.finished_at::timestamptz, p.embedding,
+                p.signals,
+                (1.0 - (p.embedding <=> query_embedding))::double precision AS similarity
+            FROM papers p
+            WHERE p.status = 'completed'
+                AND p.embedding IS NOT NULL
+                AND p.paper_uuid != ALL(exclude_uuids)
+            ORDER BY p.embedding <=> query_embedding
+            LIMIT match_count;
+        END;
+        $$ LANGUAGE plpgsql STABLE;
+    """))
+
+
+def downgrade() -> None:
+    """Restore RPC without casts (broken state)."""
+    connection = op.get_bind()
+
+    connection.execute(sa.text(
+        "DROP FUNCTION IF EXISTS match_papers_by_embedding(vector, int, text[])"
+    ))
+    connection.execute(sa.text("""
+        CREATE FUNCTION match_papers_by_embedding(
+            query_embedding vector(1536),
+            match_count int DEFAULT 20,
+            exclude_uuids text[] DEFAULT '{}'
+        )
+        RETURNS TABLE (
+            paper_uuid text,
+            title text,
+            authors text,
+            finished_at timestamptz,
+            embedding vector(1536),
+            signals jsonb,
+            similarity float
+        ) AS $$
+        BEGIN
+            RETURN QUERY
+            SELECT
+                p.paper_uuid, p.title, p.authors,
+                p.finished_at, p.embedding,
+                p.signals,
+                1.0 - (p.embedding <=> query_embedding) AS similarity
+            FROM papers p
+            WHERE p.status = 'completed'
+                AND p.embedding IS NOT NULL
+                AND p.paper_uuid != ALL(exclude_uuids)
+            ORDER BY p.embedding <=> query_embedding
+            LIMIT match_count;
+        END;
+        $$ LANGUAGE plpgsql STABLE;
+    """))

--- a/web/src/app/api/user/clusters/route.ts
+++ b/web/src/app/api/user/clusters/route.ts
@@ -1,0 +1,98 @@
+/**
+ * User Clusters API Route
+ *
+ * Returns the authenticated user's preference clusters with top matching
+ * paper titles per cluster, for display on the settings page.
+ *
+ * Responsibilities:
+ * - Authenticate the user from Supabase session
+ * - Fetch preference clusters via interactions service
+ * - For each cluster, find the top 3 matching papers by embedding similarity
+ * - Return clusters with metadata for UI display
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getPreferenceClusters } from '@/services/interactions.service';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface ClusterWithPapers {
+  clusterIndex: number;
+  weight: number;
+  interactionCount: number;
+  updatedAt: string;
+  topPapers: { paperUuid: string; title: string; similarity: number }[];
+}
+
+interface ClustersResponse {
+  clusters: ClusterWithPapers[];
+}
+
+interface ErrorResponse {
+  error: string;
+}
+
+// ============================================================================
+// MAIN HANDLERS
+// ============================================================================
+
+/**
+ * GET handler for user preference clusters.
+ * Returns clusters with top 3 matching papers each.
+ * @returns ClustersResponse on success, 401 if unauthenticated, 500 on error
+ */
+export async function GET(): Promise<NextResponse<ClustersResponse | ErrorResponse>> {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const clusters = await getPreferenceClusters(user.id);
+
+    // For each cluster, find top 3 matching papers via the RPC
+    const clustersWithPapers: ClusterWithPapers[] = await Promise.all(
+      clusters.map(async (cluster) => {
+        const vectorString = `[${cluster.embedding.join(',')}]`;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data, error } = await (supabase.rpc as any)(
+          'match_papers_by_embedding',
+          {
+            query_embedding: vectorString,
+            match_count: 3,
+            exclude_uuids: [],
+          }
+        );
+
+        const topPapers = error
+          ? []
+          : ((data ?? []) as { paper_uuid: string; title: string; similarity: number }[]).map(
+              (row) => ({
+                paperUuid: row.paper_uuid,
+                title: row.title ?? 'Untitled',
+                similarity: Math.round(row.similarity * 1000) / 1000,
+              })
+            );
+
+        return {
+          clusterIndex: cluster.clusterIndex,
+          weight: Math.round(cluster.weight * 100) / 100,
+          interactionCount: cluster.interactionCount,
+          updatedAt: cluster.updatedAt,
+          topPapers,
+        };
+      })
+    );
+
+    return NextResponse.json({ clusters: clustersWithPapers });
+  } catch (error) {
+    console.error('Error fetching user clusters:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/web/src/app/user/layout.tsx
+++ b/web/src/app/user/layout.tsx
@@ -14,6 +14,7 @@ type TabItem = {
 const TAB_ITEMS: TabItem[] = [
   { href: '/user/list', label: 'My list' },
   { href: '/user/requests', label: 'My requests' },
+  { href: '/user/personalization', label: 'Personalization' },
 ];
 
 /**

--- a/web/src/app/user/personalization/page.tsx
+++ b/web/src/app/user/personalization/page.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+/**
+ * User Personalization Page
+ *
+ * Shows the user's active preference clusters that drive feed personalization.
+ * Each cluster shows its strength, interaction count, last update, and top
+ * matching papers.
+ *
+ * Responsibilities:
+ * - Fetch preference clusters from the API
+ * - Display clusters as cards with metadata and top papers
+ * - Show empty state when no clusters exist yet
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useSession } from '@/services/auth';
+import { Loader } from 'lucide-react';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface ClusterTopPaper {
+  paperUuid: string;
+  title: string;
+  similarity: number;
+}
+
+interface ClusterData {
+  clusterIndex: number;
+  weight: number;
+  interactionCount: number;
+  updatedAt: string;
+  topPapers: ClusterTopPaper[];
+}
+
+// ============================================================================
+// MAIN HANDLERS
+// ============================================================================
+
+/**
+ * Personalization page showing active preference clusters.
+ * @returns Page component displaying user preference clusters
+ */
+export default function UserPersonalizationPage() {
+  const { user } = useSession();
+  const [clusters, setClusters] = useState<ClusterData[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string>('');
+
+  // Fetch clusters from API
+  useEffect(() => {
+    const fetchClusters = async () => {
+      if (!user?.id) {
+        setLoading(false);
+        return;
+      }
+      try {
+        setLoading(true);
+        const res = await fetch('/api/user/clusters');
+        if (!res.ok) {
+          throw new Error(`Failed to fetch clusters: ${res.status}`);
+        }
+        const data = await res.json();
+        setClusters(data.clusters ?? []);
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'Failed to load clusters';
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchClusters();
+  }, [user?.id]);
+
+  // ============================================================================
+  // RENDER
+  // ============================================================================
+
+  return (
+    <div className="p-6 h-full flex flex-col min-h-0 overflow-auto">
+      <h1 className="text-xl font-semibold">Personalization</h1>
+      <p className="text-sm text-gray-600 dark:text-gray-300 mt-1 mb-4">
+        As you interact with papers, we build interest clusters to personalize your feed.
+        Each cluster represents a topic area you&apos;ve shown interest in.
+      </p>
+
+        {error && (
+          <div className="mb-4 p-3 rounded-md border border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/40 dark:text-red-300 text-sm">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center text-sm text-gray-500 dark:text-gray-400">
+            <Loader className="animate-spin w-4 h-4 mr-2" /> Loading clusters...
+          </div>
+        ) : clusters.length === 0 ? (
+          <div className="p-4 rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-sm text-gray-600 dark:text-gray-300">
+            No interest clusters yet. Start reading and expanding papers on the home feed to build your personalized profile.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {clusters.map((cluster) => (
+              <ClusterCard key={cluster.clusterIndex} cluster={cluster} />
+            ))}
+          </div>
+        )}
+    </div>
+  );
+}
+
+// ============================================================================
+// COMPONENTS
+// ============================================================================
+
+/**
+ * Renders a single preference cluster as a card.
+ * @param cluster - The cluster data to display
+ * @returns Card with cluster metadata and top matching papers
+ */
+function ClusterCard({ cluster }: { cluster: ClusterData }) {
+  const updatedDate = new Date(cluster.updatedAt);
+  const daysAgo = Math.floor((Date.now() - updatedDate.getTime()) / (1000 * 60 * 60 * 24));
+  const updatedLabel = daysAgo === 0 ? 'today' : daysAgo === 1 ? '1 day ago' : `${daysAgo} days ago`;
+
+  return (
+    <div className="p-4 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+      {/* Header row */}
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-sm font-medium">Cluster {cluster.clusterIndex + 1}</span>
+        <span className="text-xs text-gray-500 dark:text-gray-400">
+          Updated {updatedLabel}
+        </span>
+      </div>
+
+      {/* Stats row */}
+      <div className="flex gap-4 mb-3 text-xs text-gray-600 dark:text-gray-400">
+        <div>
+          <span className="text-gray-400 dark:text-gray-500">Strength: </span>
+          <span className="font-medium text-gray-700 dark:text-gray-300">{cluster.weight}</span>
+        </div>
+        <div>
+          <span className="text-gray-400 dark:text-gray-500">Interactions: </span>
+          <span className="font-medium text-gray-700 dark:text-gray-300">{cluster.interactionCount}</span>
+        </div>
+      </div>
+
+      {/* Top matching papers */}
+      {cluster.topPapers.length > 0 && (
+        <div>
+          <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">Top matching papers:</p>
+          <ul className="space-y-1">
+            {cluster.topPapers.map((paper) => (
+              <li key={paper.paperUuid} className="flex items-start gap-2 text-xs">
+                <span className="shrink-0 mt-0.5 px-1.5 py-0.5 rounded bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 font-mono">
+                  {paper.similarity.toFixed(2)}
+                </span>
+                <span className="text-gray-700 dark:text-gray-300 line-clamp-1">{paper.title}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/UserSidebar.tsx
+++ b/web/src/components/UserSidebar.tsx
@@ -12,7 +12,7 @@ type SidebarItem = {
 const ITEMS: SidebarItem[] = [
   { href: '/user/list', label: 'My list' },
   { href: '/user/requests', label: 'My requests' },
-  // Future: { href: '/user/settings', label: 'Settings' },
+  { href: '/user/personalization', label: 'Personalization' },
 ];
 
 /**


### PR DESCRIPTION
Fixes the zero-similarity issue and adds user visibility into preference clusters.

1. Add embedding generation during paper processing (Step 6) so every newly processed paper gets a 1536-dim embedding immediately. If embedding fails, paper processing fails (no fallback).

2. Fix match_papers_by_embedding RPC function which was broken due to return type mismatch (declared text/timestamptz but actual columns are varchar/timestamp). PostgreSQL refuses implicit casts inside RETURNS TABLE. Added explicit casts to fix.

3. Add Personalization page at /user/personalization showing active preference clusters with strength, interaction count, last update, and top 3 matching papers per cluster. New API route GET /api/user/clusters. Updated navigation to include Personalization in both desktop sidebar and mobile tabs.