### PR TITLE
Add user reading activity tracking

### DIFF
--- a/.docs/plans/2026.03.12-user-reading-activity.md
+++ b/.docs/plans/2026.03.12-user-reading-activity.md
@@ -206,21 +206,21 @@ The `user_interactions` table already exists with a `metadata` JSONB column. Add
 
 ## Phases
 
-### Phase 1: Tracking Enhancement
-- [ ] Modify `useReadingTracker.ts` -- add `activeTimeSeconds` as third argument to `onReadComplete` callback
-- [ ] Modify `useInteractionTracker.ts` -- update `InteractionTrackerReturn` interface and `trackRead` to accept and store `activeTimeSeconds`
-- [ ] Update `page.tsx` (`PaperCardWithTracking`) -- update `onReadComplete` prop type and `trackRead` call site to pass `activeTimeSeconds`
+### Phase 1: Tracking Enhancement [DONE]
+- [x] Modify `useReadingTracker.ts` -- add `activeTimeSeconds` as third argument to `onReadComplete` callback
+- [x] Modify `useInteractionTracker.ts` -- update `InteractionTrackerReturn` interface and `trackRead` to accept and store `activeTimeSeconds`
+- [x] Update `page.tsx` (`PaperCardWithTracking`) -- update `onReadComplete` prop type and `trackRead` call site to pass `activeTimeSeconds`
 
-### Phase 2: Backend Stats Endpoint
-- [ ] Add `InteractionStats` and `ReadingHistoryItem` types to `recommendation.ts`
-- [ ] Add `getInteractionStats` method to `interactions.service.ts`
-- [ ] Create `api/users/me/interactions/stats/route.ts` with GET handler
+### Phase 2: Backend Stats Endpoint [DONE]
+- [x] Add `InteractionStats` and `ReadingHistoryItem` types to `recommendation.ts`
+- [x] Add `getInteractionStats` method to `interactions.service.ts`
+- [x] Create `api/users/me/interactions/stats/route.ts` with GET handler
 
-### Phase 3: Frontend Activity Page
-- [ ] Create `ActivityStats.tsx` component
-- [ ] Create `ReadingHistory.tsx` component
-- [ ] Create `activity/page.tsx` page
-- [ ] Add navigation entries in `UserSidebar.tsx` and `layout.tsx`
+### Phase 3: Frontend Activity Page [DONE]
+- [x] Create `ActivityStats.tsx` component
+- [x] Create `ReadingHistory.tsx` component
+- [x] Create `activity/page.tsx` page
+- [x] Add navigation entries in `UserSidebar.tsx` and `layout.tsx`
 
 ---
 

--- a/web/src/app/api/users/me/interactions/stats/route.ts
+++ b/web/src/app/api/users/me/interactions/stats/route.ts
@@ -1,0 +1,52 @@
+/**
+ * User Interaction Stats API Route
+ *
+ * Returns aggregated interaction statistics and reading history for the
+ * authenticated user.
+ *
+ * Responsibilities:
+ * - GET: Authenticate user and return interaction stats (counts, reading time, history)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import * as interactionsService from '@/services/interactions.service';
+import type { InteractionStats } from '@/types/recommendation';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface ErrorResponse {
+  error: string;
+}
+
+// ============================================================================
+// MAIN HANDLERS
+// ============================================================================
+
+/**
+ * GET handler for user interaction stats.
+ * Requires authentication (anonymous or permanent user).
+ * @param _request - The incoming request (unused)
+ * @returns InteractionStats on success, 401 if unauthenticated, 500 on error
+ */
+export async function GET(
+  _request: NextRequest
+): Promise<NextResponse<InteractionStats | ErrorResponse>> {
+  try {
+    // Verify authentication
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const stats = await interactionsService.getInteractionStats(user.id);
+
+    return NextResponse.json(stats);
+  } catch (error) {
+    console.error('Error fetching interaction stats:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -69,7 +69,7 @@ const PaperCardWithTracking = ({
   summary?: PaperSummaryResponse;
   onToggleExpand: (paperUuid: string) => void;
   onLoadSummary?: (paperUuid: string) => void;
-  onReadComplete: (paperUuid: string, readingRatio: number) => void;
+  onReadComplete: (paperUuid: string, readingRatio: number, activeTimeSeconds: number) => void;
 }) => {
   const impressionRef = usePaperImpression(paper.paperUuid, true);
   const wordCount = estimateWordCount(summary?.fiveMinuteSummary);

--- a/web/src/app/user/activity/page.tsx
+++ b/web/src/app/user/activity/page.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+/**
+ * User Activity Page
+ *
+ * Displays aggregated reading activity stats and a chronological reading history.
+ *
+ * Responsibilities:
+ * - Fetch interaction stats from the API
+ * - Render ActivityStats card grid and ReadingHistory table
+ * - Handle loading, error, and empty states
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useSession } from '@/services/auth';
+import { Loader } from 'lucide-react';
+import type { InteractionStats } from '@/types/recommendation';
+import ActivityStats from '@/components/ActivityStats';
+import ReadingHistory from '@/components/ReadingHistory';
+
+// ============================================================================
+// COMPONENT
+// ============================================================================
+
+/**
+ * Fetches user interaction stats and renders activity overview.
+ * @returns Activity page with stat cards and reading history table
+ */
+export default function UserActivityPage(): React.JSX.Element {
+  const { user } = useSession();
+  const [stats, setStats] = useState<InteractionStats | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string>('');
+
+  // Fetch interaction stats
+  useEffect(() => {
+    const run = async () => {
+      if (!user?.id) {
+        setLoading(false);
+        return;
+      }
+      try {
+        setLoading(true);
+        const res = await fetch('/api/users/me/interactions/stats');
+        if (!res.ok) {
+          throw new Error('Failed to load activity stats');
+        }
+        const data: InteractionStats = await res.json();
+        setStats(data);
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'Failed to load activity stats';
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    run();
+  }, [user?.id]);
+
+  if (!user?.id) {
+    return (
+      <div className="p-6 h-full flex flex-col min-h-0">
+        <h1 className="text-xl font-semibold mb-2">My activity</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-300">Please sign in to view your activity.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 h-full flex flex-col min-h-0">
+      <h1 className="text-xl font-semibold">My activity</h1>
+      <p className="text-sm text-gray-600 dark:text-gray-300 mt-1 mb-4">Your reading activity and stats.</p>
+
+      {error && (
+        <div className="mb-4 p-3 rounded-md border border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/40 dark:text-red-300 text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="flex-1 min-h-0">
+        {loading ? (
+          <div className="flex items-center text-sm text-gray-500 dark:text-gray-400">
+            <Loader className="animate-spin w-4 h-4 mr-2" /> Loading...
+          </div>
+        ) : stats ? (
+          <div className="h-full overflow-auto space-y-6">
+            <ActivityStats
+              totalExpanded={stats.totalExpanded}
+              totalRead={stats.totalRead}
+              totalSaved={stats.totalSaved}
+              totalReadingTimeSeconds={stats.totalReadingTimeSeconds}
+            />
+            <div>
+              <h2 className="text-lg font-semibold mb-3">Reading history</h2>
+              <ReadingHistory items={stats.readingHistory} />
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-gray-600 dark:text-gray-300">No activity yet.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/user/layout.tsx
+++ b/web/src/app/user/layout.tsx
@@ -14,6 +14,7 @@ type TabItem = {
 const TAB_ITEMS: TabItem[] = [
   { href: '/user/list', label: 'My list' },
   { href: '/user/requests', label: 'My requests' },
+  { href: '/user/activity', label: 'My activity' },
   { href: '/user/personalization', label: 'Personalization' },
 ];
 

--- a/web/src/components/ActivityStats.tsx
+++ b/web/src/components/ActivityStats.tsx
@@ -1,0 +1,82 @@
+/**
+ * Activity Stats Card Grid
+ *
+ * Renders 4 stat cards showing aggregated user reading activity.
+ *
+ * Responsibilities:
+ * - Display total papers seen, read, saved, and reading time
+ * - Format reading time from seconds into human-readable format (e.g. "2h 15m")
+ */
+
+import React from 'react';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface ActivityStatsProps {
+  /** Total number of papers expanded (previewed) */
+  totalExpanded: number;
+  /** Total number of papers read (scrolled past threshold) */
+  totalRead: number;
+  /** Total number of papers saved */
+  totalSaved: number;
+  /** Total active reading time across all reads, in seconds */
+  totalReadingTimeSeconds: number;
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Formats seconds into a human-readable duration string.
+ * @param seconds - Total seconds to format
+ * @returns Formatted string like "2h 15m", "45m", or "0m"
+ */
+function formatReadingTime(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+}
+
+// ============================================================================
+// COMPONENT
+// ============================================================================
+
+/**
+ * Renders 4 stat cards in a responsive grid showing user activity totals.
+ * @param props - Aggregated interaction stats
+ * @returns Grid of stat cards
+ */
+export default function ActivityStats({
+  totalExpanded,
+  totalRead,
+  totalSaved,
+  totalReadingTimeSeconds,
+}: ActivityStatsProps): React.JSX.Element {
+  const cards = [
+    { label: 'Papers seen', value: totalExpanded },
+    { label: 'Papers read', value: totalRead },
+    { label: 'Papers saved', value: totalSaved },
+    { label: 'Reading time', value: formatReadingTime(totalReadingTimeSeconds) },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      {cards.map((card) => (
+        <div
+          key={card.label}
+          className="p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800"
+        >
+          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">{card.value}</div>
+          <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">{card.label}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/PaperCard.tsx
+++ b/web/src/components/PaperCard.tsx
@@ -27,8 +27,8 @@ interface PaperCardProps {
   summary?: PaperSummaryResponse;
   onToggleExpand: (paperUuid: string) => void;
   onLoadSummary?: (paperUuid: string) => void;
-  /** Ref from useReadingTracker to attach to the expanded summary content */
-  readingTrackerRef?: React.RefObject<HTMLDivElement | null>;
+  /** Callback ref from useReadingTracker to attach to the expanded summary content */
+  readingTrackerRef?: ((node: HTMLDivElement | null) => void);
 }
 
 const GENERATE_DURATION_MS = 15_000;

--- a/web/src/components/ReadingHistory.tsx
+++ b/web/src/components/ReadingHistory.tsx
@@ -1,0 +1,116 @@
+/**
+ * Reading History Table
+ *
+ * Renders a table of recently opened papers with reading time details.
+ *
+ * Responsibilities:
+ * - Display paper title (linked to paper page when slug is available)
+ * - Show total reading time and last-opened date
+ * - Show paper thumbnail when available
+ */
+
+import React from 'react';
+import type { ReadingHistoryItem } from '@/types/recommendation';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface ReadingHistoryProps {
+  /** List of reading history entries to display */
+  items: ReadingHistoryItem[];
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Formats seconds into a short duration string.
+ * @param seconds - Duration in seconds
+ * @returns Formatted string like "5m 30s", "12s", or "-" for 0
+ */
+function formatDuration(seconds: number): string {
+  if (seconds === 0) return '-';
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  if (mins > 0) {
+    return `${mins}m ${secs}s`;
+  }
+  return `${secs}s`;
+}
+
+/**
+ * Formats an ISO date string into a readable date/time.
+ * @param isoString - ISO 8601 timestamp
+ * @returns Formatted date string
+ */
+function formatDate(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
+}
+
+// ============================================================================
+// COMPONENT
+// ============================================================================
+
+/**
+ * Renders a table of opened papers with title, reading time, and last-opened date.
+ * @param props - Reading history items
+ * @returns Table of reading history entries
+ */
+export default function ReadingHistory({ items }: ReadingHistoryProps): React.JSX.Element {
+  if (items.length === 0) {
+    return <p className="text-sm text-gray-600 dark:text-gray-300">No reading history yet.</p>;
+  }
+
+  return (
+    <div className="overflow-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="text-left border-b border-gray-200 dark:border-gray-700">
+            <th className="p-2 w-24">Image</th>
+            <th className="p-2">Title</th>
+            <th className="p-2 w-28">Reading time</th>
+            <th className="p-2 w-40">Last opened</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => {
+            const href = item.slug
+              ? `/paper/${encodeURIComponent(item.slug)}`
+              : `/paper/${encodeURIComponent(item.paperUuid)}`;
+
+            return (
+              <tr key={item.paperUuid} className="border-b border-gray-100 dark:border-gray-800">
+                <td className="p-2 align-top">
+                  {item.thumbnailUrl ? (
+                    <a href={href}>
+                      <img src={item.thumbnailUrl} alt="" className="w-20 h-14 object-cover rounded" />
+                    </a>
+                  ) : (
+                    <div className="w-20 h-14 bg-gray-200 dark:bg-gray-700 rounded" />
+                  )}
+                </td>
+                <td className="p-2 align-top">
+                  <a href={href} className="font-medium hover:underline">
+                    {item.title || item.paperUuid}
+                  </a>
+                  {item.authors && (
+                    <div className="text-xs text-gray-600 dark:text-gray-400 truncate">{item.authors}</div>
+                  )}
+                </td>
+                <td className="p-2 align-top whitespace-nowrap text-xs text-gray-700 dark:text-gray-300">
+                  {formatDuration(item.activeTimeSeconds)}
+                </td>
+                <td className="p-2 align-top whitespace-nowrap text-xs text-gray-700 dark:text-gray-300">
+                  {formatDate(item.lastOpenedAt)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/src/components/UserSidebar.tsx
+++ b/web/src/components/UserSidebar.tsx
@@ -12,6 +12,7 @@ type SidebarItem = {
 const ITEMS: SidebarItem[] = [
   { href: '/user/list', label: 'My list' },
   { href: '/user/requests', label: 'My requests' },
+  { href: '/user/activity', label: 'My activity' },
   { href: '/user/personalization', label: 'Personalization' },
 ];
 

--- a/web/src/hooks/useInteractionTracker.ts
+++ b/web/src/hooks/useInteractionTracker.ts
@@ -33,8 +33,8 @@ const INTERACTIONS_ENDPOINT = '/api/users/me/interactions';
 export interface InteractionTrackerReturn {
   /** Track a paper expand event */
   trackExpand: (paperUuid: string) => void;
-  /** Track a paper read event with reading ratio */
-  trackRead: (paperUuid: string, readingRatio: number) => void;
+  /** Track a paper read event with reading ratio and active reading time */
+  trackRead: (paperUuid: string, readingRatio: number, activeTimeSeconds: number) => void;
   /** Track a paper save event (only fires for non-anonymous users) */
   trackSave: (paperUuid: string) => void;
   /** Get all paper UUIDs interacted with this session */
@@ -154,11 +154,11 @@ export function useInteractionTracker(): InteractionTrackerReturn {
     });
   }, []);
 
-  const trackRead = useCallback((paperUuid: string, readingRatio: number) => {
+  const trackRead = useCallback((paperUuid: string, readingRatio: number, activeTimeSeconds: number) => {
     bufferRef.current.push({
       paperUuid,
       interactionType: 'read',
-      metadata: { readingRatio },
+      metadata: { readingRatio, activeTimeSeconds },
     });
   }, []);
 

--- a/web/src/hooks/useReadingTracker.ts
+++ b/web/src/hooks/useReadingTracker.ts
@@ -10,10 +10,10 @@
  * - Track whether the summary div is visible in the viewport
  * - Detect user activity (scroll, mouse, touch) within the summary div
  * - Accumulate active reading time and compute a reading ratio
- * - Fire a callback when the paper collapses/unmounts if readingRatio > 0.4
+ * - Fire a callback with reading time when the paper collapses/unmounts
  */
 
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useCallback } from 'react';
 
 // ============================================================================
 // CONSTANTS
@@ -21,20 +21,20 @@ import { useRef, useEffect, useCallback } from 'react';
 
 /** Words per minute reading speed assumption */
 const READING_SPEED_WPM = 200;
-/** Minimum reading ratio to trigger the onReadComplete callback */
-const MIN_READING_RATIO = 0.4;
 /** Activity timeout -- user is "inactive" if no event for this many ms */
 const ACTIVITY_TIMEOUT_MS = 15_000;
 /** Throttle interval for activity event listeners */
 const ACTIVITY_THROTTLE_MS = 300;
+/** Heartbeat interval in ms for accumulating active time */
+const HEARTBEAT_MS = 1000;
 
 // ============================================================================
 // TYPES
 // ============================================================================
 
 export interface ReadingTrackerResult {
-  /** Ref to attach to the expanded summary content div */
-  ref: React.RefObject<HTMLDivElement | null>;
+  /** Callback ref to attach to the expanded summary content div */
+  ref: (node: HTMLDivElement | null) => void;
   /** Whether the user is currently actively reading */
   isActivelyReading: boolean;
 }
@@ -45,111 +45,108 @@ export interface ReadingTrackerResult {
 
 /**
  * Tracks active reading time for an expanded paper summary.
- * Uses IntersectionObserver to detect visibility and activity listeners
+ * Uses a callback ref to start/stop tracking when the element mounts/unmounts.
+ * Sets up IntersectionObserver for visibility and activity listeners
  * (scroll, mousemove, touchstart) scoped to the summary div.
- * Fires onReadComplete when the paper collapses or unmounts if the user
- * read for at least 40% of the expected reading time.
+ * Fires onReadComplete when the element unmounts (paper collapses) if any
+ * active reading time was accumulated.
  *
  * @param paperUuid - UUID of the paper being read
  * @param wordCount - Number of words in the summary
- * @param onReadComplete - Callback fired with (paperUuid, readingRatio) when reading ends
- * @returns Object with ref to attach to the summary div and active reading state
+ * @param onReadComplete - Callback fired with (paperUuid, readingRatio, activeTimeSeconds) on unmount
+ * @returns Object with callback ref to attach to the summary div and active reading state
  */
 export function useReadingTracker(
   paperUuid: string,
   wordCount: number,
-  onReadComplete: (paperUuid: string, readingRatio: number) => void
+  onReadComplete: (paperUuid: string, readingRatio: number, activeTimeSeconds: number) => void
 ): ReadingTrackerResult {
-  const ref = useRef<HTMLDivElement | null>(null);
   const isActivelyReadingRef = useRef(false);
-  const isInViewportRef = useRef(false);
-  const lastActivityRef = useRef<number>(0);
-  const activeTimeRef = useRef<number>(0);
-  const lastTickRef = useRef<number>(0);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const hasFiredRef = useRef(false);
+  const cleanupRef = useRef<(() => void) | null>(null);
 
   // Expected reading time in ms
   const expectedReadingTimeMs = (wordCount / READING_SPEED_WPM) * 60 * 1000;
 
-  // Fire the callback if enough reading happened
-  const fireIfQualified = useCallback(() => {
-    if (hasFiredRef.current || expectedReadingTimeMs <= 0) return;
-
-    const ratio = activeTimeRef.current / expectedReadingTimeMs;
-    if (ratio > MIN_READING_RATIO) {
-      hasFiredRef.current = true;
-      onReadComplete(paperUuid, ratio);
+  // Callback ref: sets up tracking when element mounts, tears down on unmount
+  const ref = useCallback((node: HTMLDivElement | null) => {
+    // Tear down previous tracking if any
+    if (cleanupRef.current) {
+      cleanupRef.current();
+      cleanupRef.current = null;
     }
-  }, [paperUuid, expectedReadingTimeMs, onReadComplete]);
 
-  useEffect(() => {
-    const element = ref.current;
-    if (!element) return;
+    if (!node) return;
+
+    // -- Tracking state for this element lifecycle --
+    let isInViewport = false;
+    let lastActivity = Date.now();
+    let activeTimeMs = 0;
+    let lastTick = Date.now();
+    let lastThrottled = 0;
 
     // -- Activity tracking (throttled) --
-    let lastThrottled = 0;
     const handleActivity = () => {
       const now = Date.now();
       if (now - lastThrottled < ACTIVITY_THROTTLE_MS) return;
       lastThrottled = now;
-      lastActivityRef.current = now;
+      lastActivity = now;
     };
 
-    element.addEventListener('scroll', handleActivity, { passive: true });
-    element.addEventListener('mousemove', handleActivity, { passive: true });
-    element.addEventListener('touchstart', handleActivity, { passive: true });
+    node.addEventListener('scroll', handleActivity, { passive: true });
+    node.addEventListener('mousemove', handleActivity, { passive: true });
+    node.addEventListener('touchstart', handleActivity, { passive: true });
 
     // -- IntersectionObserver --
     const observer = new IntersectionObserver(
       ([entry]) => {
-        isInViewportRef.current = entry.isIntersecting;
+        isInViewport = entry.isIntersecting;
         if (entry.isIntersecting) {
-          // Start tracking -- mark activity so the first tick counts
-          lastActivityRef.current = Date.now();
-          lastTickRef.current = Date.now();
+          lastActivity = Date.now();
+          lastTick = Date.now();
         }
       },
       { threshold: 0.3 }
     );
-    observer.observe(element);
+    observer.observe(node);
 
     // -- Heartbeat interval to accumulate active time --
-    intervalRef.current = setInterval(() => {
+    const interval = setInterval(() => {
       const now = Date.now();
-      const isActive = isInViewportRef.current
-        && (now - lastActivityRef.current < ACTIVITY_TIMEOUT_MS);
+      const isActive = isInViewport && (now - lastActivity < ACTIVITY_TIMEOUT_MS);
 
       isActivelyReadingRef.current = isActive;
 
-      if (isActive && lastTickRef.current > 0) {
-        activeTimeRef.current += now - lastTickRef.current;
+      if (isActive && lastTick > 0) {
+        activeTimeMs += now - lastTick;
       }
-      lastTickRef.current = now;
-    }, 1000);
+      lastTick = now;
+    }, HEARTBEAT_MS);
 
-    // -- Cleanup --
-    return () => {
+    // -- Cleanup function: called when element unmounts or ref changes --
+    cleanupRef.current = () => {
       // Accumulate any final active time
       const now = Date.now();
-      const isActive = isInViewportRef.current
-        && (now - lastActivityRef.current < ACTIVITY_TIMEOUT_MS);
-      if (isActive && lastTickRef.current > 0) {
-        activeTimeRef.current += now - lastTickRef.current;
+      const isActive = isInViewport && (now - lastActivity < ACTIVITY_TIMEOUT_MS);
+      if (isActive && lastTick > 0) {
+        activeTimeMs += now - lastTick;
       }
 
-      fireIfQualified();
-
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
+      // Fire callback if any reading time was accumulated
+      if (activeTimeMs > 0) {
+        const ratio = expectedReadingTimeMs > 0
+          ? activeTimeMs / expectedReadingTimeMs
+          : 0;
+        onReadComplete(paperUuid, ratio, Math.round(activeTimeMs / 1000));
       }
+
+      clearInterval(interval);
       observer.disconnect();
-
-      element.removeEventListener('scroll', handleActivity);
-      element.removeEventListener('mousemove', handleActivity);
-      element.removeEventListener('touchstart', handleActivity);
+      node.removeEventListener('scroll', handleActivity);
+      node.removeEventListener('mousemove', handleActivity);
+      node.removeEventListener('touchstart', handleActivity);
+      isActivelyReadingRef.current = false;
     };
-  }, [fireIfQualified]);
+  }, [paperUuid, expectedReadingTimeMs, onReadComplete]);
 
   return {
     ref,

--- a/web/src/services/interactions.service.ts
+++ b/web/src/services/interactions.service.ts
@@ -8,10 +8,17 @@
  * - Batch-insert interaction events into the user_interactions table
  * - Update preference clusters based on interacted paper embeddings
  * - Retrieve preference clusters with daily weight decay
+ * - Aggregate interaction stats and reading history for the activity page
  */
 
 import { createClient } from '@/lib/supabase/server';
-import type { InteractionEvent, UserPreferenceCluster } from '@/types/recommendation';
+import type {
+  InteractionEvent,
+  InteractionStats,
+  ReadingHistoryItem,
+  UserPreferenceCluster,
+} from '@/types/recommendation';
+import { getPaperThumbnailUrls } from '@/lib/supabase/storage';
 
 // ============================================================================
 // CONSTANTS
@@ -31,6 +38,9 @@ const CENTROID_NEW_WEIGHT = 0.2;
 
 /** Daily decay factor applied to cluster weights */
 const DAILY_WEIGHT_DECAY = 0.95;
+
+/** Maximum number of recent reads returned in reading history */
+const READING_HISTORY_LIMIT = 50;
 
 // ============================================================================
 // MAIN HANDLERS
@@ -321,9 +331,188 @@ export async function getPreferenceClusters(
   });
 }
 
+/**
+ * Returns aggregated interaction stats and reading history for a user.
+ * Uses two queries: one for counts/totals, one for the 50 most recent reads with paper details.
+ * @param userId - Supabase auth.uid() of the user
+ * @returns Aggregated stats with reading history
+ */
+export async function getInteractionStats(userId: string): Promise<InteractionStats> {
+  const supabase = await createClient();
+
+  // Query 1: Fetch all interactions with minimal projection for aggregation
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: allInteractions, error: aggError } = await (supabase
+    .from('user_interactions') as any)
+    .select('interaction_type, metadata')
+    .eq('user_id', userId);
+
+  if (aggError) {
+    throw new Error(`Failed to fetch interaction stats: ${aggError.message}`);
+  }
+
+  // Client-side aggregation by interaction_type
+  const rows = (allInteractions ?? []) as {
+    interaction_type: string;
+    metadata: Record<string, unknown> | null;
+  }[];
+
+  let totalExpanded = 0;
+  let totalRead = 0;
+  let totalSaved = 0;
+  let totalReadingTimeSeconds = 0;
+
+  for (const row of rows) {
+    switch (row.interaction_type) {
+      case 'expanded':
+        totalExpanded++;
+        break;
+      case 'read':
+        totalRead++;
+        // Sum activeTimeSeconds, treating null/missing as 0
+        if (row.metadata && typeof row.metadata.activeTimeSeconds === 'number') {
+          totalReadingTimeSeconds += row.metadata.activeTimeSeconds;
+        }
+        break;
+      case 'saved':
+        totalSaved++;
+        break;
+    }
+  }
+
+  // Query 2: Fetch expanded interactions to build per-paper history
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: expandedRows, error: expandError } = await (supabase
+    .from('user_interactions') as any)
+    .select('paper_uuid, created_at')
+    .eq('user_id', userId)
+    .eq('interaction_type', 'expanded')
+    .order('created_at', { ascending: false });
+
+  if (expandError) {
+    throw new Error(`Failed to fetch expanded history: ${expandError.message}`);
+  }
+
+  // Query 3: Fetch all read interactions to aggregate reading time per paper
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: readRows, error: readsError } = await (supabase
+    .from('user_interactions') as any)
+    .select('paper_uuid, metadata')
+    .eq('user_id', userId)
+    .eq('interaction_type', 'read');
+
+  if (readsError) {
+    throw new Error(`Failed to fetch reading history: ${readsError.message}`);
+  }
+
+  // Build reading history: one row per unique paper, ordered by last opened
+  const readingHistory = await buildReadingHistory(
+    supabase,
+    (expandedRows ?? []) as { paper_uuid: string; created_at: string }[],
+    (readRows ?? []) as { paper_uuid: string; metadata: Record<string, unknown> | null }[]
+  );
+
+  return {
+    totalExpanded,
+    totalRead,
+    totalSaved,
+    totalReadingTimeSeconds,
+    readingHistory,
+  };
+}
+
 // ============================================================================
 // HELPER FUNCTIONS
 // ============================================================================
+
+/**
+ * Builds the reading history: one row per unique paper, ordered by last opened.
+ * Aggregates total reading time from read events and uses the latest expand timestamp.
+ * @param supabase - Supabase client instance
+ * @param expandedRows - Raw expanded interaction rows (sorted by created_at desc)
+ * @param readRows - Raw read interaction rows with metadata
+ * @returns Array of ReadingHistoryItem with paper details, capped at READING_HISTORY_LIMIT
+ */
+async function buildReadingHistory(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  expandedRows: { paper_uuid: string; created_at: string }[],
+  readRows: { paper_uuid: string; metadata: Record<string, unknown> | null }[]
+): Promise<ReadingHistoryItem[]> {
+  if (expandedRows.length === 0) return [];
+
+  // Group expanded rows by paper: keep only the latest timestamp per paper
+  const lastOpenedMap = new Map<string, string>();
+  for (const row of expandedRows) {
+    if (!lastOpenedMap.has(row.paper_uuid)) {
+      // Rows are sorted desc, so first occurrence is the latest
+      lastOpenedMap.set(row.paper_uuid, row.created_at);
+    }
+  }
+
+  // Sum activeTimeSeconds per paper from read events
+  const readingTimeMap = new Map<string, number>();
+  for (const row of readRows) {
+    if (row.metadata && typeof row.metadata.activeTimeSeconds === 'number') {
+      const current = readingTimeMap.get(row.paper_uuid) ?? 0;
+      readingTimeMap.set(row.paper_uuid, current + row.metadata.activeTimeSeconds);
+    }
+  }
+
+  // Build ordered list of unique paper UUIDs (by last opened, desc), capped at limit
+  const orderedUuids: string[] = [];
+  for (const row of expandedRows) {
+    if (!orderedUuids.includes(row.paper_uuid)) {
+      orderedUuids.push(row.paper_uuid);
+      if (orderedUuids.length >= READING_HISTORY_LIMIT) break;
+    }
+  }
+
+  // Batch-fetch paper details, slugs, and thumbnails in parallel
+  const [papersResult, slugsResult, thumbnailMap] = await Promise.all([
+    supabase
+      .from('papers')
+      .select('paper_uuid, title, authors')
+      .in('paper_uuid', orderedUuids),
+    supabase
+      .from('paper_slugs')
+      .select('paper_uuid, slug')
+      .in('paper_uuid', orderedUuids),
+    getPaperThumbnailUrls(orderedUuids),
+  ]);
+
+  if (papersResult.error) {
+    throw new Error(`Failed to fetch papers: ${papersResult.error.message}`);
+  }
+  if (slugsResult.error) {
+    throw new Error(`Failed to fetch paper slugs: ${slugsResult.error.message}`);
+  }
+
+  // Build lookup maps
+  const paperMap = new Map<string, { title: string | null; authors: string | null }>();
+  for (const p of (papersResult.data ?? []) as { paper_uuid: string; title: string | null; authors: string | null }[]) {
+    paperMap.set(p.paper_uuid, { title: p.title, authors: p.authors });
+  }
+
+  const slugMap = new Map<string, string>();
+  for (const s of (slugsResult.data ?? []) as { paper_uuid: string; slug: string }[]) {
+    slugMap.set(s.paper_uuid, s.slug);
+  }
+
+  // Assemble reading history items
+  return orderedUuids.map((uuid) => {
+    const paper = paperMap.get(uuid);
+    return {
+      paperUuid: uuid,
+      title: paper?.title ?? null,
+      authors: paper?.authors ?? null,
+      slug: slugMap.get(uuid) ?? null,
+      thumbnailUrl: thumbnailMap.get(uuid) ?? null,
+      activeTimeSeconds: readingTimeMap.get(uuid) ?? 0,
+      lastOpenedAt: lastOpenedMap.get(uuid)!,
+    };
+  });
+}
 
 /**
  * Computes cosine similarity between two vectors.

--- a/web/src/types/recommendation.ts
+++ b/web/src/types/recommendation.ts
@@ -97,6 +97,47 @@ export interface FeedResponse {
 }
 
 // ============================================================================
+// INTERFACES - Interaction Stats
+// ============================================================================
+
+/**
+ * Aggregated interaction statistics for a user.
+ */
+export interface InteractionStats {
+  /** Total number of papers expanded (previewed) */
+  totalExpanded: number;
+  /** Total number of papers read (scrolled past threshold) */
+  totalRead: number;
+  /** Total number of papers saved */
+  totalSaved: number;
+  /** Total active reading time across all reads, in seconds */
+  totalReadingTimeSeconds: number;
+  /** 50 most recently opened papers with aggregated reading time */
+  readingHistory: ReadingHistoryItem[];
+}
+
+/**
+ * A single entry in the user's reading history.
+ * One row per unique paper, showing total reading time and last-opened timestamp.
+ */
+export interface ReadingHistoryItem {
+  /** UUID of the paper */
+  paperUuid: string;
+  /** Paper title (null if paper row is missing) */
+  title: string | null;
+  /** Paper authors (null if paper row is missing) */
+  authors: string | null;
+  /** URL-friendly slug (null if no slug exists) */
+  slug: string | null;
+  /** Signed thumbnail URL (null if no thumbnail in storage) */
+  thumbnailUrl: string | null;
+  /** Total active reading time in seconds across all sessions */
+  activeTimeSeconds: number;
+  /** ISO timestamp when the paper was last opened */
+  lastOpenedAt: string;
+}
+
+// ============================================================================
 // INTERFACES - User Preference Clusters
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Adds a user activity page showing reading statistics and history. Users can now see papers they've opened, how long they spent reading each, and when they last accessed them. Reading time is tracked automatically as users interact with papers on the home feed.

## What changed

**Backend:**
- New `/api/users/me/interactions/stats` endpoint that returns aggregated interaction statistics: total papers seen (expanded), read, saved, and total reading time in seconds. Also includes a reading history list of the 50 most recently opened papers with their aggregated reading time.
- Updated interaction tracking to capture active reading time in seconds when users close a paper, storing it in the interaction event metadata.

**Frontend:**
- New "My activity" page under `/user/activity` with stat cards (papers seen, read, saved, reading time) and a table showing reading history.
- Fixed reading time detection: changed from object refs to callback refs in useReadingTracker so tracking starts immediately when a paper expands (previously tracking never initialized because the ref wasn't attached to the DOM until the effect had already run).
- Removed the 40% reading ratio gate so any amount of reading time is recorded, not just when users read past a threshold.
- Added "My activity" nav entry in the user sidebar and tabs.

## Why

Provides users with visibility into their reading habits and engagement with papers. The feature helps users understand what they've been reading and encourages continued exploration of the platform.

## How

**Reading time tracking:**
- When a paper expands, useReadingTracker attaches listeners (scroll, mousemove, touchstart) to the summary div and starts an IntersectionObserver to detect visibility.
- A 1-second heartbeat accumulates active time when the div is visible and the user has interacted in the last 15 seconds (activity timeout).
- When the paper collapses, accumulated time is sent as a read interaction event with activeTimeSeconds in metadata.

**Stats aggregation:**
- Query 1 fetches all interactions to count papers expanded, read, saved and sum reading time.
- Query 2 fetches 50 most recent expanded interactions, grouped by paper with the latest timestamp.
- Query 3 fetches read interactions to aggregate reading time per paper.
- Results are merged to show one row per paper with total reading time and last-opened date.

## How to test

1. Expand several papers on the home feed and read for varying amounts of time (move mouse, scroll).
2. Close the papers.
3. Wait 15 seconds for the interaction buffer to flush (or trigger manually by hiding the tab).
4. Navigate to "My activity" in the user sidebar.
5. Verify stat cards show correct counts and reading time.
6. Verify reading history table shows the papers you opened with their reading times and last-opened dates.
7. Open a paper again and close it - verify the reading time updates in the history.

## Tech debt and future work

- Reading time only counts when a user is actively interacting with the page (moving mouse, scrolling, touching). If a user reads without interacting, the clock pauses after 15 seconds. This could be improved with page visibility API or other heuristics if needed.
- Old interaction rows from before this feature deployed won't have activeTimeSeconds in metadata - they show as 0 reading time, which is acceptable given this is a new feature.