### PR TITLE
Fix nested asyncio.run() error in embedding generation

### DIFF
--- a/worker/dags/backfill_embeddings_dag.py
+++ b/worker/dags/backfill_embeddings_dag.py
@@ -168,7 +168,8 @@ def backfill_embeddings_dag():
                 try:
                     abstract = paper.get("abstract")
 
-                    embedding = generate_embedding(title, abstract)
+                    import asyncio
+                    embedding = asyncio.run(generate_embedding(title, abstract))
                     save_embedding(paper_uuid, embedding)
                     updated += 1
 

--- a/worker/paperprocessor/client.py
+++ b/worker/paperprocessor/client.py
@@ -227,7 +227,7 @@ async def process_paper_pdf(pdf_contents: bytes, paper_id: Optional[str] = None)
 
         # Step 6: Generate embedding for similarity search
         logger.info("Step 6: Generating embedding.")
-        document.embedding = generate_embedding(document.title, document.abstract)
+        document.embedding = await generate_embedding(document.title, document.abstract)
 
         logger.info("Paper processing pipeline v2 finished (simplified).")
         return document

--- a/worker/paperprocessor/embedding.py
+++ b/worker/paperprocessor/embedding.py
@@ -10,7 +10,6 @@ Responsibilities:
 - Return a single embedding vector for the paper
 """
 
-import asyncio
 import logging
 from typing import List, Optional
 
@@ -24,7 +23,7 @@ logger = logging.getLogger(__name__)
 # ============================================================================
 
 
-def generate_embedding(title: str, abstract: Optional[str] = None) -> List[float]:
+async def generate_embedding(title: str, abstract: Optional[str] = None) -> List[float]:
     """
     Generate a 1536-dimensional embedding for a paper from its title and abstract.
 
@@ -44,8 +43,7 @@ def generate_embedding(title: str, abstract: Optional[str] = None) -> List[float
     else:
         text = title
 
-    # Call the OpenRouter embeddings endpoint (async -> sync bridge)
-    embeddings = asyncio.run(get_embeddings([text]))
+    embeddings = await get_embeddings([text])
 
     if not embeddings:
         raise ValueError(f"OpenRouter returned no embeddings for text: {text[:100]}...")


### PR DESCRIPTION
## What

The paper processing DAG was failing with 'asyncio.run() cannot be called from a running event loop' during Step 6 (embedding generation). This occurred because `generate_embedding()` called `asyncio.run()` to invoke an async function, but the parent task was already running inside an event loop started by Airflow.

## Why

The issue stems from nested event loops: the DAG task executor creates an event loop via `asyncio.run()`, then the paper processing pipeline tries to create another loop inside that one when calling `generate_embedding()`. Python doesn't allow nested `asyncio.run()` calls.

## How

- Made `generate_embedding()` an async function that awaits `get_embeddings()` directly instead of wrapping it with `asyncio.run()`
- Updated the caller in `client.py` to `await` the function (already in async context)
- For the backfill embeddings DAG (which runs synchronously), added `asyncio.run()` wrapper since that code path has no existing event loop

## Testing

Run the paper processing DAG (`paper_processing_worker_dag`) with papers that need embedding generation. Step 6 should complete without the 'running event loop' error. The backfill embeddings DAG should continue working as before.