### PR TITLE
Fix admin users list to use Supabase Auth API

### DIFF
--- a/web/src/services/users.service.ts
+++ b/web/src/services/users.service.ts
@@ -7,6 +7,7 @@
  */
 
 import { createClient } from '@/lib/supabase/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 import { getPaperThumbnailUrl } from '@/lib/supabase/storage';
 import type {
   CreatedResponse,
@@ -730,31 +731,38 @@ export async function getProcessingMetrics(
  * @returns Array of admin user items sorted by creation date (newest first)
  */
 export async function listAllUsers(): Promise<AdminUserItem[]> {
-  const supabase = await createClient();
+  // User data lives in auth.users (Supabase Auth), not a public table.
+  // Use the Auth Admin API via a service role client to list users.
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceRoleKey) {
+    throw new Error('SUPABASE_SERVICE_ROLE_KEY is not set -- cannot list auth users');
+  }
+  const serviceClient = createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    serviceRoleKey
+  );
 
-  // Fetch all users
-  const { data: usersData, error: usersError } = await supabase
-    .from('users')
-    .select('id, email, created_at')
-    .order('created_at', { ascending: false });
+  // Fetch all auth users (paginated, max 1000 per page)
+  const { data: authData, error: authError } = await serviceClient.auth.admin.listUsers({
+    perPage: 1000,
+    page: 1,
+  });
 
-  if (usersError) throw new Error(usersError.message);
+  if (authError) throw new Error(authError.message);
 
-  const users = (usersData ?? []) as Array<{
-    id: string;
-    email: string;
-    created_at: string;
-  }>;
+  // Filter out anonymous users (they have no email)
+  const realUsers = authData.users.filter((u) => !u.is_anonymous && u.email);
 
-  // Fetch all user_lists and user_requests counts in parallel
-  const userIds = users.map((u) => u.id);
+  // Collect user IDs for activity count queries
+  const userIds = realUsers.map((u) => u.id);
 
+  // Fetch user_lists and user_requests counts in parallel
   const [listsResult, requestsResult] = await Promise.all([
-    supabase
+    serviceClient
       .from('user_lists')
       .select('user_id')
       .in('user_id', userIds),
-    supabase
+    serviceClient
       .from('user_requests')
       .select('user_id')
       .in('user_id', userIds),
@@ -774,9 +782,14 @@ export async function listAllUsers(): Promise<AdminUserItem[]> {
     requestCounts.set(row.user_id, (requestCounts.get(row.user_id) ?? 0) + 1);
   }
 
-  return users.map((user) => ({
+  // Sort newest first
+  const sorted = realUsers.sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  );
+
+  return sorted.map((user) => ({
     id: user.id,
-    email: user.email,
+    email: user.email ?? '',
     createdAt: user.created_at,
     savedPapersCount: listCounts.get(user.id) ?? 0,
     requestsCount: requestCounts.get(user.id) ?? 0,


### PR DESCRIPTION
## Summary

Fixed the admin users management page (`/management/users`) to work with actual database schema:
- The `public.users` table doesn't exist (was dropped); user data lives in `auth.users` (Supabase Auth)
- Updated `listAllUsers()` to use `auth.admin.listUsers()` API
- Filters out anonymous users (only shows real users with emails)
- Fetches activity counts from `user_lists` and `user_requests` tables
- Returns users sorted by creation date (newest first)

This resolves the 500 error "Could not find the table 'public.users' in the schema cache"

## Test plan

- [ ] Navigate to /management/users with admin auth
- [ ] Verify 1 real user (arthur.stockman.me@gmail.com) displays with correct counts
- [ ] Check that anonymous users are filtered out
- [ ] Verify summary stats are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)