### PR TITLE
Implement: Hide previously seen papers from user feed

### DIFF
--- a/.docs/plans/2026.03.13-hide-seen-papers.md
+++ b/.docs/plans/2026.03.13-hide-seen-papers.md
@@ -129,27 +129,27 @@ After this change, the server independently queries seen/interacted UUIDs. The c
 
 ### Phase 1: Type and tracker changes
 
-- [ ] Add `'seen'` to `InteractionType` union in `recommendation.ts`
-- [ ] Add `trackSeen` method to `useInteractionTracker` with session-level deduplication
-- [ ] Update `InteractionTrackerReturn` interface to expose `trackSeen`
+- [x] Add `'seen'` to `InteractionType` union in `recommendation.ts`
+- [x] Add `trackSeen` method to `useInteractionTracker` with session-level deduplication
+- [x] Update `InteractionTrackerReturn` interface to expose `trackSeen`
 
 ### Phase 2: Filter seen events from cluster updates
 
-- [ ] In `/api/users/me/interactions/route.ts`, filter `paperUuids` passed to `updatePreferenceClusters`: build `clusterPaperUuids` from events where `interactionType` is `'expanded'` or `'read'` only, and pass that to `updatePreferenceClusters` instead of the full `paperUuids` list. If `clusterPaperUuids` is empty, skip the `after()` call entirely.
+- [x] In `/api/users/me/interactions/route.ts`, filter `paperUuids` passed to `updatePreferenceClusters`: build `clusterPaperUuids` from events where `interactionType` is `'expanded'` or `'read'` only, and pass that to `updatePreferenceClusters` instead of the full `paperUuids` list. If `clusterPaperUuids` is empty, skip the `after()` call entirely.
 
 > **Note:** This must land before or alongside Phase 3, otherwise `seen` events will pollute preference clusters in the window between deployment.
 
 ### Phase 3: Wire impression hook to interaction tracker
 
-- [ ] Modify `usePaperImpression` to accept an `onSeen` callback parameter (third positional arg)
-- [ ] Add `onSeen` to the `useEffect` dependency array for the IntersectionObserver
-- [ ] Call `onSeen(paperUuid)` inside the `hasBeenSeen` flip block
-- [ ] In `PaperCardWithTracking` in `page.tsx`, pass `trackSeen` as the `onSeen` callback to `usePaperImpression`
+- [x] Modify `usePaperImpression` to accept an `onSeen` callback parameter (third positional arg)
+- [x] Add `onSeen` to the `useEffect` dependency array for the IntersectionObserver
+- [x] Call `onSeen(paperUuid)` inside the `hasBeenSeen` flip block
+- [x] In `PaperCardWithTracking` in `page.tsx`, pass `trackSeen` as the `onSeen` callback to `usePaperImpression`
 
 ### Phase 4: Server-side seen paper exclusion
 
-- [ ] Add `getInteractedPaperUuids(userId)` to `interactions.service.ts`
-- [ ] In `getRankedFeed` in `feed.service.ts`, call `getInteractedPaperUuids` when `userId` is non-null and merge into `excludePaperUuids`
+- [x] Add `getInteractedPaperUuids(userId)` to `interactions.service.ts`
+- [x] In `getRankedFeed` in `feed.service.ts`, call `getInteractedPaperUuids` when `userId` is non-null and merge into `excludePaperUuids`
 
 ---
 

--- a/web/src/app/api/users/me/interactions/route.ts
+++ b/web/src/app/api/users/me/interactions/route.ts
@@ -60,17 +60,24 @@ export async function POST(
 
     await interactionsService.saveInteractions(user.id, body.events);
 
-    // Extract unique paper UUIDs for cluster update
-    const paperUuids = [...new Set(body.events.map((e) => e.paperUuid))];
+    // Extract unique paper UUIDs from expanded/read events only for cluster update
+    // Seen and saved events should not influence preference clusters
+    const clusterPaperUuids = [...new Set(
+      body.events
+        .filter((e) => e.interactionType === 'expanded' || e.interactionType === 'read')
+        .map((e) => e.paperUuid)
+    )];
 
-    // Trigger async cluster update after response is sent
-    after(async () => {
-      try {
-        await interactionsService.updatePreferenceClusters(user.id, paperUuids);
-      } catch (err) {
-        console.error('Error updating preference clusters:', err);
-      }
-    });
+    // Trigger async cluster update after response is sent (only if there are relevant events)
+    if (clusterPaperUuids.length > 0) {
+      after(async () => {
+        try {
+          await interactionsService.updatePreferenceClusters(user.id, clusterPaperUuids);
+        } catch (err) {
+          console.error('Error updating preference clusters:', err);
+        }
+      });
+    }
 
     return NextResponse.json({ ok: true as const });
   } catch (error) {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -60,6 +60,7 @@ const PaperCardWithTracking = ({
   onToggleExpand,
   onLoadSummary,
   onReadComplete,
+  onSeen,
 }: {
   paper: MinimalPaperItem;
   isExpanded: boolean;
@@ -70,8 +71,9 @@ const PaperCardWithTracking = ({
   onToggleExpand: (paperUuid: string) => void;
   onLoadSummary?: (paperUuid: string) => void;
   onReadComplete: (paperUuid: string, readingRatio: number, activeTimeSeconds: number) => void;
+  onSeen?: (paperUuid: string) => void;
 }) => {
-  const impressionRef = usePaperImpression(paper.paperUuid, true);
+  const impressionRef = usePaperImpression(paper.paperUuid, true, onSeen);
   const wordCount = estimateWordCount(summary?.fiveMinuteSummary);
   const { ref: readingRef } = useReadingTracker(
     paper.paperUuid,
@@ -115,7 +117,7 @@ export default function ScrollingPapersPage() {
   const observerTarget = useRef<HTMLDivElement>(null);
 
   // Interaction tracking for feed recommendations
-  const { trackExpand, trackRead, getSessionPaperUuids } = useInteractionTracker();
+  const { trackExpand, trackRead, trackSeen, getSessionPaperUuids } = useInteractionTracker();
 
   // ============================================================================
   // EVENT HANDLERS
@@ -372,6 +374,7 @@ export default function ScrollingPapersPage() {
                 onToggleExpand={toggleExpanded}
                 onLoadSummary={loadPaperSummary}
                 onReadComplete={trackRead}
+                onSeen={trackSeen}
               />
             );
           })}

--- a/web/src/hooks/useInteractionTracker.ts
+++ b/web/src/hooks/useInteractionTracker.ts
@@ -3,7 +3,7 @@
 /**
  * Interaction Tracker Hook
  *
- * Session-level tracker that collects user interaction events (expand, read, save)
+ * Session-level tracker that collects user interaction events (expand, read, save, seen)
  * and flushes them to the backend API.
  *
  * Responsibilities:
@@ -37,6 +37,8 @@ export interface InteractionTrackerReturn {
   trackRead: (paperUuid: string, readingRatio: number, activeTimeSeconds: number) => void;
   /** Track a paper save event (only fires for non-anonymous users) */
   trackSave: (paperUuid: string) => void;
+  /** Track a paper seen event (fired when a paper card scrolls into view) */
+  trackSeen: (paperUuid: string) => void;
   /** Get all paper UUIDs interacted with this session */
   getSessionPaperUuids: () => string[];
 }
@@ -172,9 +174,26 @@ export function useInteractionTracker(): InteractionTrackerReturn {
     });
   }, []);
 
+  /**
+   * Track a paper seen (impression) event.
+   * Deduplicates within the session: if the paper is already in
+   * sessionPaperUuidsRef, the buffer push is skipped.
+   * @param paperUuid - UUID of the paper that scrolled into view
+   */
+  const trackSeen = useCallback((paperUuid: string) => {
+    // Skip if already tracked this session (handles remounts from scrolling)
+    if (sessionPaperUuidsRef.current.has(paperUuid)) return;
+
+    sessionPaperUuidsRef.current.add(paperUuid);
+    bufferRef.current.push({
+      paperUuid,
+      interactionType: 'seen',
+    });
+  }, []);
+
   const getSessionPaperUuids = useCallback((): string[] => {
     return Array.from(sessionPaperUuidsRef.current);
   }, []);
 
-  return { trackExpand, trackRead, trackSave, getSessionPaperUuids };
+  return { trackExpand, trackRead, trackSave, trackSeen, getSessionPaperUuids };
 }

--- a/web/src/hooks/useUmamiTracking.ts
+++ b/web/src/hooks/useUmamiTracking.ts
@@ -15,9 +15,10 @@ declare global {
  *   each time the paper leaves the viewport or the tab is hidden.
  * @param paperUuid - The UUID of the paper to track.
  * @param enabled - Whether the hook is active.
+ * @param onSeen - Optional callback fired once when the paper first scrolls into view.
  * @returns A ref to attach to the element to be observed.
  */
-export const usePaperImpression = (paperUuid: string, enabled: boolean) => {
+export const usePaperImpression = (paperUuid: string, enabled: boolean, onSeen?: (paperUuid: string) => void) => {
   const ref = useRef<HTMLDivElement>(null);
   const hasBeenSeen = useRef(false);
   const startTime = useRef<number | null>(null);
@@ -75,6 +76,7 @@ export const usePaperImpression = (paperUuid: string, enabled: boolean) => {
           if (!hasBeenSeen.current) {
             hasBeenSeen.current = true;
             trackImpression();
+            onSeen?.(paperUuid);
           }
           // Start the timer
           startTime.current = Date.now();
@@ -95,7 +97,7 @@ export const usePaperImpression = (paperUuid: string, enabled: boolean) => {
       trackDuration(); // Track any final duration when the component unmounts
       observer.unobserve(currentElement);
     };
-  }, [enabled, trackImpression, trackDuration]);
+  }, [enabled, trackImpression, trackDuration, onSeen]);
 
   return ref;
 };

--- a/web/src/services/feed.service.ts
+++ b/web/src/services/feed.service.ts
@@ -16,7 +16,7 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { getPaperThumbnailUrls } from '@/lib/supabase/storage';
-import { getPreferenceClusters } from '@/services/interactions.service';
+import { getPreferenceClusters, getInteractedPaperUuids } from '@/services/interactions.service';
 import type { FeedResponse } from '@/types/recommendation';
 import type { MinimalPaper } from '@/types/paper';
 
@@ -110,6 +110,13 @@ export async function getRankedFeed(
   excludePaperUuids: string[],
   userId: string | null
 ): Promise<FeedResponse> {
+  // Merge previously interacted paper UUIDs into the exclude list
+  if (userId) {
+    const interactedUuids = await getInteractedPaperUuids(userId);
+    const mergedExcludes = new Set([...excludePaperUuids, ...interactedUuids]);
+    excludePaperUuids = Array.from(mergedExcludes);
+  }
+
   // Build preference vectors (empty for unauthenticated or cold-start users)
   const preferenceVectors = userId
     ? await buildPreferenceVectors(userId)

--- a/web/src/services/interactions.service.ts
+++ b/web/src/services/interactions.service.ts
@@ -332,6 +332,33 @@ export async function getPreferenceClusters(
 }
 
 /**
+ * Returns distinct paper UUIDs the user has interacted with (any interaction type).
+ * Used to exclude previously seen/interacted papers from the feed.
+ * @param userId - Supabase auth.uid() of the user
+ * @returns Flat array of paper UUID strings
+ */
+export async function getInteractedPaperUuids(userId: string): Promise<string[]> {
+  const supabase = await createClient();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase.from('user_interactions') as any)
+    .select('paper_uuid')
+    .eq('user_id', userId);
+
+  if (error) {
+    throw new Error(`Failed to fetch interacted paper UUIDs: ${error.message}`);
+  }
+
+  // Extract distinct paper UUIDs
+  const uuids = new Set<string>();
+  for (const row of (data ?? []) as { paper_uuid: string }[]) {
+    uuids.add(row.paper_uuid);
+  }
+
+  return Array.from(uuids);
+}
+
+/**
  * Returns aggregated interaction stats and reading history for a user.
  * Uses two queries: one for counts/totals, one for the 50 most recent reads with paper details.
  * @param userId - Supabase auth.uid() of the user

--- a/web/src/types/recommendation.ts
+++ b/web/src/types/recommendation.ts
@@ -17,7 +17,7 @@ import type { MinimalPaper } from './paper';
 // ============================================================================
 
 /** Types of user interactions tracked by the system */
-export type InteractionType = 'expanded' | 'read' | 'saved';
+export type InteractionType = 'expanded' | 'read' | 'saved' | 'seen';
 
 // ============================================================================
 // INTERFACES - Interaction Events


### PR DESCRIPTION
## What

Users now see fewer repeated papers in their feed. Papers that have been scrolled past (seen), expanded, read, or saved are excluded from the ranked feed on subsequent sessions. This uses a new 'seen' interaction type tracked when paper cards scroll into the viewport.

## Why

Currently the feed only excludes papers loaded in the active session via in-memory state. Users were seeing the same papers repeatedly across sessions, reducing the utility of the feed. Persisting "seen" impressions to the database solves this by giving the recommendation engine a complete view of papers the user has already encountered.

## How

The implementation adds a four-phase pipeline:

1. **Client tracking**: When a paper card enters the viewport (via IntersectionObserver), a 'seen' event is recorded to the interaction tracker with session-level deduplication to prevent duplicate entries when cards remount during scrolling.

2. **Server persistence**: Batched interaction events are flushed to the backend every 15 seconds. All event types (expanded, read, saved, seen) are persisted to the `user_interactions` table.

3. **Cluster filtering**: Only 'expanded' and 'read' events influence preference clusters. 'seen' and 'saved' events do not update user interests, since passive scrolling should not signal explicit interest.

4. **Feed exclusion**: When generating the ranked feed, the server queries all papers the user has interacted with and merges them into the exclusion list before scoring and ranking candidates.

## How to test

- Load the feed and scroll past 10 papers
- Close the browser and return later
- Verify those 10 papers no longer appear in the feed
- Confirm papers you expanded, read, or saved are also excluded
- Check Supabase `user_interactions` table to verify 'seen' rows are created
- Confirm the feed still works for new users with no interaction history

## Tech debt and future work

- The `getInteractedPaperUuids` query currently returns all interacted papers with no time limit. Future work could add a "forget older interactions" policy (e.g., exclude papers older than 90 days) to allow re-discovery of old papers.
- Currently using Set-based deduplication on the client; if interaction volume grows significantly, consider using a bloom filter or database-side deduplication.