### PR TITLE
Optimize: Convert 1 page for metadata, increase concurrency to 4, run every 2 hours

### DIFF
--- a/worker/dags/paper_processing_worker_dag.py
+++ b/worker/dags/paper_processing_worker_dag.py
@@ -30,7 +30,7 @@ from users.client import set_requests_processed
 
 MAX_PDF_PAGES = 70
 MAX_PAPERS_PER_RUN = 500
-MAX_PARALLEL_TASKS = 2
+MAX_PARALLEL_TASKS = 4
 
 
 # ============================================================================
@@ -487,7 +487,7 @@ async def _process_paper_job_complete(job: JobInfo) -> None:
 @dag(
     dag_id="paper_processing_worker",
     start_date=pendulum.datetime(2025, 1, 1, tz="UTC"),
-    schedule="0 2,14 * * *",  # Twice daily at 2 AM and 2 PM UTC
+    schedule="0 */2 * * *",  # Every 2 hours
     catchup=False,
     max_active_runs=1,  # Prevent overlapping runs
     max_active_tasks=MAX_PARALLEL_TASKS,  # Maximum concurrent paper processing tasks
@@ -497,8 +497,8 @@ async def _process_paper_job_complete(job: JobInfo) -> None:
 
     This DAG processes papers from the queue that are in 'not_started' status.
 
-    - Runs twice daily at 2 AM and 2 PM UTC
-    - Processes up to 10 papers per run (randomly selected, processed in parallel)
+    - Runs every 2 hours
+    - Processes up to 500 papers per run (randomly selected, processed in parallel)
     - Processes papers through simplified pipeline: PDF download → image conversion (first 3 pages) → metadata extraction → abstract summary → embedding → saving → slug creation
     - Uses database locking to prevent race conditions
     - Handles errors gracefully and marks failed jobs

--- a/worker/paperprocessor/client.py
+++ b/worker/paperprocessor/client.py
@@ -161,7 +161,7 @@ async def process_paper_pdf(
 ) -> ProcessedDocument:
         """
         PDF processing pipeline (no OCR):
-        1. Convert first 3 pages to images (for thumbnail + fallback metadata extraction)
+        1. Convert PDF pages to images (1 page for thumbnail if metadata provided, 3 pages otherwise)
         2. Set metadata from caller (e.g. arXiv API) or extract via LLM
         3. Generate abstract summary
         4. Generate embedding
@@ -182,9 +182,13 @@ async def process_paper_pdf(
 
         pdf_base64 = base64.b64encode(pdf_contents).decode('utf-8')
 
-        # Step 1: Convert first 3 pages to images (for thumbnail + fallback metadata)
-        logger.info("Step 1: Converting first 3 pages to images.")
-        images = await convert_pdf_to_images(pdf_contents)
+        # Step 1: Convert PDF pages to images
+        # With pre-extracted metadata + abstract, only need page 1 (thumbnail)
+        # Without, need 3 pages for LLM metadata extraction and abstract fallback
+        has_full_metadata = bool(title and authors and abstract)
+        max_pages = 1 if has_full_metadata else 3
+        logger.info(f"Step 1: Converting first {max_pages} page(s) to images.")
+        images = await convert_pdf_to_images(pdf_contents, max_pages=max_pages)
 
         pages = []
         for i, image in enumerate(images):


### PR DESCRIPTION
## Summary

Optimized paper processing pipeline: convert only 1 PDF page (for thumbnail) when arXiv metadata is available, increased worker concurrency to 4, and changed schedule to run every 2 hours for faster queue processing.

## Changes

- **Image conversion**: Intelligently convert 1 page (thumbnail) when metadata provided, 3 pages for LLM extraction fallback
- **Concurrency**: Increased MAX_PARALLEL_TASKS from 2 to 4 for faster parallel processing
- **Schedule**: Changed from twice-daily (2 AM/2 PM UTC) to every 2 hours for more responsive queue handling

🤖 Generated with Claude Code