### PR TITLE
Increase recency half-life from 7 to 14 days

### DIFF
--- a/web/src/services/feed.service.ts
+++ b/web/src/services/feed.service.ts
@@ -40,7 +40,7 @@ const HF_UPVOTES_WEIGHT = 0.33;
 const H_INDEX_CAP = 50;
 
 /** Half-life in days for the recency exponential decay */
-const RECENCY_HALF_LIFE_DAYS = 7;
+const RECENCY_HALF_LIFE_DAYS = 14;
 
 /** Number of ANN candidates to fetch per preference cluster */
 const CANDIDATES_PER_CLUSTER = 50;


### PR DESCRIPTION
Extends the recency decay half-life in the feed ranking algorithm from 7 to 14 days. Papers now maintain half their recency score over 2 weeks instead of 1 week, allowing older papers to contribute more to feed diversity and improving the long-tail of paper recommendations.