### PR TITLE
Capture raw reading signals and wire save events

### DIFF
--- a/web/src/app/api/users/me/interactions/route.ts
+++ b/web/src/app/api/users/me/interactions/route.ts
@@ -60,11 +60,11 @@ export async function POST(
 
     await interactionsService.saveInteractions(user.id, body.events);
 
-    // Extract unique paper UUIDs from expanded/read events only for cluster update
-    // Seen and saved events should not influence preference clusters
+    // Extract unique paper UUIDs from expanded/read/saved events for cluster update
+    // Seen events should not influence preference clusters
     const clusterPaperUuids = [...new Set(
       body.events
-        .filter((e) => e.interactionType === 'expanded' || e.interactionType === 'read')
+        .filter((e) => e.interactionType === 'expanded' || e.interactionType === 'read' || e.interactionType === 'saved')
         .map((e) => e.paperUuid)
     )];
 

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -61,6 +61,7 @@ const PaperCardWithTracking = ({
   onLoadSummary,
   onReadComplete,
   onSeen,
+  onSave,
 }: {
   paper: MinimalPaperItem;
   isExpanded: boolean;
@@ -70,8 +71,9 @@ const PaperCardWithTracking = ({
   summary?: PaperSummaryResponse;
   onToggleExpand: (paperUuid: string) => void;
   onLoadSummary?: (paperUuid: string) => void;
-  onReadComplete: (paperUuid: string, readingRatio: number, activeTimeSeconds: number) => void;
+  onReadComplete: (paperUuid: string, wordCount: number, activeTimeSeconds: number) => void;
   onSeen?: (paperUuid: string) => void;
+  onSave?: (paperUuid: string) => void;
 }) => {
   const impressionRef = usePaperImpression(paper.paperUuid, true, onSeen);
   const wordCount = estimateWordCount(summary?.fiveMinuteSummary);
@@ -93,6 +95,7 @@ const PaperCardWithTracking = ({
       onToggleExpand={onToggleExpand}
       onLoadSummary={onLoadSummary}
       readingTrackerRef={isExpanded ? readingRef : undefined}
+      onSave={onSave}
     />
   );
 };
@@ -117,7 +120,7 @@ export default function ScrollingPapersPage() {
   const observerTarget = useRef<HTMLDivElement>(null);
 
   // Interaction tracking for feed recommendations
-  const { trackExpand, trackRead, trackSeen, getSessionPaperUuids } = useInteractionTracker();
+  const { trackExpand, trackRead, trackSave, trackSeen, getSessionPaperUuids } = useInteractionTracker();
 
   // ============================================================================
   // EVENT HANDLERS
@@ -375,6 +378,7 @@ export default function ScrollingPapersPage() {
                 onLoadSummary={loadPaperSummary}
                 onReadComplete={trackRead}
                 onSeen={trackSeen}
+                onSave={trackSave}
               />
             );
           })}

--- a/web/src/components/AddToListButton.tsx
+++ b/web/src/components/AddToListButton.tsx
@@ -10,6 +10,7 @@ import { setPostLoginCookie } from '@/lib/postLogin';
 type AddToListButtonProps = {
   paperId: string;
   redirectTo?: string;
+  onSave?: (paperId: string) => void;
 };
 
 /**
@@ -19,7 +20,7 @@ type AddToListButtonProps = {
  * @param redirectTo - URL to redirect to after login (defaults to current path)
  * @returns Add to list button component
  */
-export default function AddToListButton({ paperId, redirectTo }: AddToListButtonProps) {
+export default function AddToListButton({ paperId, redirectTo, onSave }: AddToListButtonProps) {
   const { user } = useSession();
   const router = useRouter();
 
@@ -75,6 +76,7 @@ export default function AddToListButton({ paperId, redirectTo }: AddToListButton
       } else {
         await addPaperToUserList(paperId);
         setIsInList(true);
+        onSave?.(paperId);
       }
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : 'Failed to update list';

--- a/web/src/components/AddToListButtonMobile.tsx
+++ b/web/src/components/AddToListButtonMobile.tsx
@@ -10,6 +10,7 @@ import { setPostLoginCookie } from '@/lib/postLogin';
 type AddToListButtonMobileProps = {
   paperId: string;
   redirectTo?: string;
+  onSave?: (paperId: string) => void;
 };
 
 /**
@@ -19,7 +20,7 @@ type AddToListButtonMobileProps = {
  * @param redirectTo - URL to redirect to after login (defaults to current path)
  * @returns Compact add to list button component for mobile
  */
-export default function AddToListButtonMobile({ paperId, redirectTo }: AddToListButtonMobileProps) {
+export default function AddToListButtonMobile({ paperId, redirectTo, onSave }: AddToListButtonMobileProps) {
   const { user } = useSession();
   const router = useRouter();
 
@@ -75,6 +76,7 @@ export default function AddToListButtonMobile({ paperId, redirectTo }: AddToList
       } else {
         await addPaperToUserList(paperId);
         setIsInList(true);
+        onSave?.(paperId);
       }
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : 'Failed to update list';

--- a/web/src/components/PaperCard.tsx
+++ b/web/src/components/PaperCard.tsx
@@ -29,6 +29,8 @@ interface PaperCardProps {
   onLoadSummary?: (paperUuid: string) => void;
   /** Callback ref from useReadingTracker to attach to the expanded summary content */
   readingTrackerRef?: ((node: HTMLDivElement | null) => void);
+  /** Callback fired when the user saves a paper to their list */
+  onSave?: (paperUuid: string) => void;
 }
 
 const GENERATE_DURATION_MS = 15_000;
@@ -43,6 +45,7 @@ const PaperCard = React.forwardRef<HTMLDivElement, PaperCardProps>(({
   onToggleExpand,
   onLoadSummary,
   readingTrackerRef,
+  onSave,
 }, ref) => {
   const [copied, setCopied] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -198,7 +201,7 @@ const PaperCard = React.forwardRef<HTMLDivElement, PaperCardProps>(({
             {/* Action buttons - bottom right corner when expanded */}
             <div className="mt-4 flex items-center justify-end gap-2">
               <CopyMarkdownButton paperUuid={paper.paperUuid} fiveMinuteSummary={summary?.fiveMinuteSummary} />
-              <AddToListButtonMobile paperId={paper.paperUuid} />
+              <AddToListButtonMobile paperId={paper.paperUuid} onSave={onSave} />
 
               {paper.slug && (
                 <button

--- a/web/src/hooks/useInteractionTracker.ts
+++ b/web/src/hooks/useInteractionTracker.ts
@@ -33,8 +33,8 @@ const INTERACTIONS_ENDPOINT = '/api/users/me/interactions';
 export interface InteractionTrackerReturn {
   /** Track a paper expand event */
   trackExpand: (paperUuid: string) => void;
-  /** Track a paper read event with reading ratio and active reading time */
-  trackRead: (paperUuid: string, readingRatio: number, activeTimeSeconds: number) => void;
+  /** Track a paper read event with word count and active reading time */
+  trackRead: (paperUuid: string, wordCount: number, activeTimeSeconds: number) => void;
   /** Track a paper save event (only fires for non-anonymous users) */
   trackSave: (paperUuid: string) => void;
   /** Track a paper seen event (fired when a paper card scrolls into view) */
@@ -156,11 +156,11 @@ export function useInteractionTracker(): InteractionTrackerReturn {
     });
   }, []);
 
-  const trackRead = useCallback((paperUuid: string, readingRatio: number, activeTimeSeconds: number) => {
+  const trackRead = useCallback((paperUuid: string, wordCount: number, activeTimeSeconds: number) => {
     bufferRef.current.push({
       paperUuid,
       interactionType: 'read',
-      metadata: { readingRatio, activeTimeSeconds },
+      metadata: { wordCount, activeTimeSeconds },
     });
   }, []);
 

--- a/web/src/hooks/useReadingTracker.ts
+++ b/web/src/hooks/useReadingTracker.ts
@@ -19,8 +19,6 @@ import { useRef, useCallback } from 'react';
 // CONSTANTS
 // ============================================================================
 
-/** Words per minute reading speed assumption */
-const READING_SPEED_WPM = 200;
 /** Activity timeout -- user is "inactive" if no event for this many ms */
 const ACTIVITY_TIMEOUT_MS = 15_000;
 /** Throttle interval for activity event listeners */
@@ -53,19 +51,16 @@ export interface ReadingTrackerResult {
  *
  * @param paperUuid - UUID of the paper being read
  * @param wordCount - Number of words in the summary
- * @param onReadComplete - Callback fired with (paperUuid, readingRatio, activeTimeSeconds) on unmount
+ * @param onReadComplete - Callback fired with (paperUuid, wordCount, activeTimeSeconds) on unmount
  * @returns Object with callback ref to attach to the summary div and active reading state
  */
 export function useReadingTracker(
   paperUuid: string,
   wordCount: number,
-  onReadComplete: (paperUuid: string, readingRatio: number, activeTimeSeconds: number) => void
+  onReadComplete: (paperUuid: string, wordCount: number, activeTimeSeconds: number) => void
 ): ReadingTrackerResult {
   const isActivelyReadingRef = useRef(false);
   const cleanupRef = useRef<(() => void) | null>(null);
-
-  // Expected reading time in ms
-  const expectedReadingTimeMs = (wordCount / READING_SPEED_WPM) * 60 * 1000;
 
   // Callback ref: sets up tracking when element mounts, tears down on unmount
   const ref = useCallback((node: HTMLDivElement | null) => {
@@ -133,10 +128,7 @@ export function useReadingTracker(
 
       // Fire callback if any reading time was accumulated
       if (activeTimeMs > 0) {
-        const ratio = expectedReadingTimeMs > 0
-          ? activeTimeMs / expectedReadingTimeMs
-          : 0;
-        onReadComplete(paperUuid, ratio, Math.round(activeTimeMs / 1000));
+        onReadComplete(paperUuid, wordCount, Math.round(activeTimeMs / 1000));
       }
 
       clearInterval(interval);
@@ -146,7 +138,7 @@ export function useReadingTracker(
       node.removeEventListener('touchstart', handleActivity);
       isActivelyReadingRef.current = false;
     };
-  }, [paperUuid, expectedReadingTimeMs, onReadComplete]);
+  }, [paperUuid, wordCount, onReadComplete]);
 
   return {
     ref,

--- a/web/src/types/recommendation.ts
+++ b/web/src/types/recommendation.ts
@@ -31,7 +31,7 @@ export interface InteractionEvent {
   paperUuid: string;
   /** Type of interaction */
   interactionType: InteractionType;
-  /** Optional metadata (e.g. { readingRatio: 0.7 } for 'read' type) */
+  /** Optional metadata (e.g. { wordCount: 450, activeTimeSeconds: 120 } for 'read' type) */
   metadata?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
Store wordCount and activeTimeSeconds instead of pre-computed readingRatio, enabling flexible future engagement calculations. Wire save events into the interaction tracking pipeline so saved papers contribute to preference clusters alongside expanded and read events. This enables the LLM re-ranker to access both implicit (reading time) and explicit (save) user preference signals needed for better recommendations.

**Changes:**
- Save raw signals (wordCount, activeTimeSeconds) instead of derived readingRatio
- Include saved interactions in preference cluster updates
- Add onSave callback to paper action buttons to trigger interaction tracking
- Verify signal capture in database