### PR TITLE
Add My Interests debug page for recommendation algorithm

### DIFF
--- a/web/src/app/api/users/me/interests/route.ts
+++ b/web/src/app/api/users/me/interests/route.ts
@@ -1,0 +1,70 @@
+/**
+ * User Interests Clustering API Route
+ *
+ * Returns the authenticated user's interacted papers grouped into clusters
+ * using on-the-fly k-means on paper embeddings.
+ *
+ * Responsibilities:
+ * - GET: Authenticate user, parse maxClusters param, return clustered papers
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getInterestClusters } from '@/services/interests.service';
+import type { InterestClustersResponse } from '@/types/interests';
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const DEFAULT_MAX_CLUSTERS = 5;
+const MIN_CLUSTERS = 1;
+const MAX_CLUSTERS = 10;
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface ErrorResponse {
+  error: string;
+}
+
+// ============================================================================
+// MAIN HANDLERS
+// ============================================================================
+
+/**
+ * GET handler for interest clusters.
+ * Accepts optional `maxClusters` query param (1-10, default 5).
+ * @param request - The incoming request with optional maxClusters query param
+ * @returns InterestClustersResponse on success, 401 if unauthenticated, 500 on error
+ */
+export async function GET(
+  request: NextRequest
+): Promise<NextResponse<InterestClustersResponse | ErrorResponse>> {
+  try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Parse and clamp maxClusters
+    const rawParam = request.nextUrl.searchParams.get('maxClusters');
+    let maxClusters = DEFAULT_MAX_CLUSTERS;
+    if (rawParam) {
+      const parsed = parseInt(rawParam, 10);
+      if (!isNaN(parsed)) {
+        maxClusters = Math.max(MIN_CLUSTERS, Math.min(MAX_CLUSTERS, parsed));
+      }
+    }
+
+    const result = await getInterestClusters(user.id, maxClusters);
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('Error fetching interest clusters:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/web/src/app/user/interests/page.tsx
+++ b/web/src/app/user/interests/page.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+/**
+ * User Interests Page
+ *
+ * Displays the user's interacted papers (opened, saved, read) grouped into
+ * clusters by topic similarity. Uses on-the-fly k-means clustering with a
+ * slider to control the number of clusters.
+ *
+ * Responsibilities:
+ * - Fetch clustered papers from the API with configurable maxClusters
+ * - Display a slider for adjusting the number of clusters
+ * - Show papers grouped by cluster in a card grid
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { useSession } from '@/services/auth';
+import { Loader } from 'lucide-react';
+import type { InterestCluster } from '@/types/interests';
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const DEFAULT_MAX_CLUSTERS = 5;
+const MIN_CLUSTERS = 1;
+const MAX_CLUSTERS = 10;
+const DEBOUNCE_MS = 300;
+
+// ============================================================================
+// MAIN HANDLERS
+// ============================================================================
+
+/**
+ * Interests page showing interacted papers grouped by topic clusters.
+ * @returns Page component with cluster slider and paper groups
+ */
+export default function UserInterestsPage(): React.JSX.Element {
+  const { user } = useSession();
+  const [clusters, setClusters] = useState<InterestCluster[]>([]);
+  const [totalPapers, setTotalPapers] = useState<number>(0);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string>('');
+  const [maxClusters, setMaxClusters] = useState<number>(DEFAULT_MAX_CLUSTERS);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Fetch clusters with debounce when maxClusters or user changes
+  useEffect(() => {
+    if (!user?.id) {
+      setLoading(false);
+      return;
+    }
+
+    // Debounce the fetch to avoid spamming while dragging the slider
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    debounceRef.current = setTimeout(async () => {
+      try {
+        setLoading(true);
+        const res = await fetch(`/api/users/me/interests?maxClusters=${maxClusters}`);
+        if (!res.ok) {
+          throw new Error(`Failed to fetch interests: ${res.status}`);
+        }
+        const data = await res.json();
+        setClusters(data.clusters ?? []);
+        setTotalPapers(data.totalPapers ?? 0);
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'Failed to load interests';
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, [user?.id, maxClusters]);
+
+  // ============================================================================
+  // EVENT HANDLERS
+  // ============================================================================
+
+  /**
+   * Updates the max clusters value from the slider input.
+   * @param e - Change event from the range input
+   */
+  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    setMaxClusters(parseInt(e.target.value, 10));
+  };
+
+  // ============================================================================
+  // RENDER
+  // ============================================================================
+
+  return (
+    <div className="p-6 h-full flex flex-col min-h-0 overflow-auto">
+      <h1 className="text-xl font-semibold">My interests</h1>
+
+      {/* Debug disclaimer */}
+      <div className="mb-4 px-3 py-2 rounded-md border border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-900/30 text-xs text-amber-800 dark:text-amber-300">
+        Internal debug view -- we are building a recommendation algorithm and use this page to
+        inspect how papers cluster based on your reading activity.
+      </div>
+
+      <p className="text-sm text-gray-600 dark:text-gray-300 mt-1 mb-4">
+        Papers you have opened, saved, or read, grouped by topic similarity.
+      </p>
+
+      {/* Cluster slider */}
+      <div className="flex items-center gap-3 mb-4">
+        <label htmlFor="cluster-slider" className="text-sm text-gray-600 dark:text-gray-300">
+          Max clusters:
+        </label>
+        <input
+          id="cluster-slider"
+          type="range"
+          min={MIN_CLUSTERS}
+          max={MAX_CLUSTERS}
+          value={maxClusters}
+          onChange={handleSliderChange}
+          className="w-48 accent-blue-600"
+        />
+        <span className="text-sm font-medium w-6 text-center">{maxClusters}</span>
+        {totalPapers > 0 && (
+          <span className="text-xs text-gray-400 dark:text-gray-500 ml-2">
+            ({totalPapers} papers)
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 rounded-md border border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/40 dark:text-red-300 text-sm">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center text-sm text-gray-500 dark:text-gray-400">
+          <Loader className="animate-spin w-4 h-4 mr-2" /> Clustering papers...
+        </div>
+      ) : clusters.length === 0 ? (
+        <div className="p-4 rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-sm text-gray-600 dark:text-gray-300">
+          No interacted papers yet. Start opening, reading, or saving papers to see your interests here.
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {clusters.map((cluster) => (
+            <ClusterSection key={cluster.clusterIndex} cluster={cluster} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// COMPONENTS
+// ============================================================================
+
+/**
+ * Renders a single cluster as a section with a heading and a grid of paper cards.
+ * @param cluster - The cluster data to display
+ * @returns Section with cluster heading and paper grid
+ */
+function ClusterSection({ cluster }: { cluster: InterestCluster }): React.JSX.Element {
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-2">
+        <h2 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          Group {cluster.clusterIndex + 1}
+        </h2>
+        <span className="text-xs text-gray-400 dark:text-gray-500">
+          ({cluster.papers.length} {cluster.papers.length === 1 ? 'paper' : 'papers'})
+        </span>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {cluster.papers.map((paper) => {
+          const href = `/paper/${encodeURIComponent(paper.slug || paper.paperUuid)}`;
+          return (
+            <a
+              key={paper.paperUuid}
+              href={href}
+              className="flex gap-3 p-3 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+            >
+              {paper.thumbnailUrl ? (
+                <img
+                  src={paper.thumbnailUrl}
+                  alt=""
+                  className="w-16 h-12 object-cover rounded flex-shrink-0"
+                />
+              ) : (
+                <div className="w-16 h-12 bg-gray-200 dark:bg-gray-700 rounded flex-shrink-0" />
+              )}
+              <div className="min-w-0">
+                <p className="text-sm font-medium line-clamp-2">{paper.title || 'Untitled'}</p>
+                {paper.authors && (
+                  <p className="text-xs text-gray-500 dark:text-gray-400 truncate mt-0.5">
+                    {paper.authors}
+                  </p>
+                )}
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/user/layout.tsx
+++ b/web/src/app/user/layout.tsx
@@ -16,6 +16,7 @@ const TAB_ITEMS: TabItem[] = [
   { href: '/user/requests', label: 'My requests' },
   { href: '/user/activity', label: 'My activity' },
   { href: '/user/personalization', label: 'Personalization' },
+  { href: '/user/interests', label: 'My interests' },
 ];
 
 /**

--- a/web/src/components/UserSidebar.tsx
+++ b/web/src/components/UserSidebar.tsx
@@ -14,6 +14,7 @@ const ITEMS: SidebarItem[] = [
   { href: '/user/requests', label: 'My requests' },
   { href: '/user/activity', label: 'My activity' },
   { href: '/user/personalization', label: 'Personalization' },
+  { href: '/user/interests', label: 'My interests' },
 ];
 
 /**

--- a/web/src/services/interests.service.ts
+++ b/web/src/services/interests.service.ts
@@ -1,0 +1,300 @@
+/**
+ * Interests Service
+ *
+ * Server-side service for on-the-fly clustering of a user's interacted papers.
+ * Uses k-means on paper embeddings to group papers by topic similarity.
+ *
+ * Responsibilities:
+ * - Fetch all papers a user has interacted with (opened, saved, read)
+ * - Run k-means clustering on paper embeddings
+ * - Return clusters with paper metadata for display
+ */
+
+import { createClient } from '@/lib/supabase/server';
+import { getPaperThumbnailUrls } from '@/lib/supabase/storage';
+import type {
+  ClusteredPaper,
+  InterestCluster,
+  InterestClustersResponse,
+} from '@/types/interests';
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/** Maximum iterations for k-means before stopping */
+const MAX_KMEANS_ITERATIONS = 20;
+
+/** Interaction types to include (excludes 'seen') */
+const INCLUDED_INTERACTION_TYPES = ['expanded', 'read', 'saved'];
+
+// ============================================================================
+// MAIN HANDLERS
+// ============================================================================
+
+/**
+ * Fetches all papers the user has interacted with and clusters them using k-means.
+ * @param userId - Supabase auth.uid() of the user
+ * @param maxClusters - Maximum number of clusters to create (actual k = min(maxClusters, numPapers))
+ * @returns Clusters of papers grouped by embedding similarity
+ */
+export async function getInterestClusters(
+  userId: string,
+  maxClusters: number
+): Promise<InterestClustersResponse> {
+  const supabase = await createClient();
+
+  // Step 1: Get distinct paper UUIDs the user has interacted with
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: interactionRows, error: interactionError } = await (supabase
+    .from('user_interactions') as any)
+    .select('paper_uuid')
+    .eq('user_id', userId)
+    .in('interaction_type', INCLUDED_INTERACTION_TYPES);
+
+  if (interactionError) {
+    throw new Error(`Failed to fetch interactions: ${interactionError.message}`);
+  }
+
+  const paperUuids = [
+    ...new Set(
+      ((interactionRows ?? []) as { paper_uuid: string }[]).map((r) => r.paper_uuid)
+    ),
+  ];
+
+  if (paperUuids.length === 0) {
+    return { clusters: [], totalPapers: 0 };
+  }
+
+  // Step 2: Fetch paper details and embeddings
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: papersData, error: papersError } = await (supabase
+    .from('papers') as any)
+    .select('paper_uuid, title, authors, embedding')
+    .in('paper_uuid', paperUuids)
+    .not('embedding', 'is', null);
+
+  if (papersError) {
+    throw new Error(`Failed to fetch papers: ${papersError.message}`);
+  }
+
+  const papers = (papersData ?? []) as {
+    paper_uuid: string;
+    title: string | null;
+    authors: string | null;
+    embedding: string;
+  }[];
+
+  if (papers.length === 0) {
+    return { clusters: [], totalPapers: 0 };
+  }
+
+  // Step 3: Fetch slugs and thumbnails in parallel
+  const uuidsWithEmbeddings = papers.map((p) => p.paper_uuid);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [slugsResult, thumbnailMap] = await Promise.all([
+    (supabase.from('paper_slugs') as any)
+      .select('paper_uuid, slug')
+      .in('paper_uuid', uuidsWithEmbeddings),
+    getPaperThumbnailUrls(uuidsWithEmbeddings),
+  ]);
+
+  if (slugsResult.error) {
+    throw new Error(`Failed to fetch slugs: ${slugsResult.error.message}`);
+  }
+
+  const slugMap = new Map<string, string>();
+  for (const s of (slugsResult.data ?? []) as { paper_uuid: string; slug: string }[]) {
+    slugMap.set(s.paper_uuid, s.slug);
+  }
+
+  // Step 4: Parse embeddings and run k-means
+  const embeddings = papers.map((p) => parseEmbeddingString(p.embedding));
+  const k = Math.min(maxClusters, papers.length);
+  const assignments = kMeans(embeddings, k);
+
+  // Step 5: Group papers by cluster assignment
+  const clusterMap = new Map<number, ClusteredPaper[]>();
+
+  for (let i = 0; i < papers.length; i++) {
+    const clusterIdx = assignments[i];
+    const paper = papers[i];
+
+    const clusteredPaper: ClusteredPaper = {
+      paperUuid: paper.paper_uuid,
+      title: paper.title,
+      authors: paper.authors,
+      slug: slugMap.get(paper.paper_uuid) ?? null,
+      thumbnailUrl: thumbnailMap.get(paper.paper_uuid) ?? null,
+    };
+
+    const existing = clusterMap.get(clusterIdx);
+    if (existing) {
+      existing.push(clusteredPaper);
+    } else {
+      clusterMap.set(clusterIdx, [clusteredPaper]);
+    }
+  }
+
+  // Build response, re-index clusters sequentially (0, 1, 2, ...)
+  const clusters: InterestCluster[] = [];
+  let idx = 0;
+  for (const [, papers] of clusterMap) {
+    clusters.push({ clusterIndex: idx, papers });
+    idx++;
+  }
+
+  return { clusters, totalPapers: papers.length };
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Runs k-means clustering on a set of embedding vectors.
+ * Uses k-means++ initialization and Lloyd's algorithm.
+ * @param embeddings - Array of embedding vectors (all same dimensionality)
+ * @param k - Number of clusters to create
+ * @returns Array of cluster assignments (one index per embedding)
+ */
+function kMeans(embeddings: number[][], k: number): number[] {
+  const n = embeddings.length;
+
+  if (k >= n) {
+    // Each paper gets its own cluster
+    return embeddings.map((_, i) => i);
+  }
+
+  // K-means++ initialization
+  const centroids = kMeansPlusPlusInit(embeddings, k);
+
+  let assignments = new Array<number>(n).fill(0);
+
+  for (let iter = 0; iter < MAX_KMEANS_ITERATIONS; iter++) {
+    // Assign each point to the nearest centroid
+    const newAssignments = new Array<number>(n);
+    for (let i = 0; i < n; i++) {
+      let bestCluster = 0;
+      let bestDist = Infinity;
+      for (let c = 0; c < k; c++) {
+        const dist = euclideanDistanceSquared(embeddings[i], centroids[c]);
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestCluster = c;
+        }
+      }
+      newAssignments[i] = bestCluster;
+    }
+
+    // Check for convergence
+    let changed = false;
+    for (let i = 0; i < n; i++) {
+      if (newAssignments[i] !== assignments[i]) {
+        changed = true;
+        break;
+      }
+    }
+    assignments = newAssignments;
+
+    if (!changed) break;
+
+    // Recompute centroids
+    const dim = embeddings[0].length;
+    const sums = Array.from({ length: k }, () => new Array<number>(dim).fill(0));
+    const counts = new Array<number>(k).fill(0);
+
+    for (let i = 0; i < n; i++) {
+      const c = assignments[i];
+      counts[c]++;
+      for (let d = 0; d < dim; d++) {
+        sums[c][d] += embeddings[i][d];
+      }
+    }
+
+    for (let c = 0; c < k; c++) {
+      if (counts[c] === 0) continue;
+      for (let d = 0; d < dim; d++) {
+        centroids[c][d] = sums[c][d] / counts[c];
+      }
+    }
+  }
+
+  return assignments;
+}
+
+/**
+ * K-means++ initialization: picks initial centroids that are spread apart.
+ * First centroid is random, subsequent ones are chosen proportional to
+ * squared distance from the nearest existing centroid.
+ * @param embeddings - Array of embedding vectors
+ * @param k - Number of centroids to pick
+ * @returns Array of k centroid vectors (copies of selected embeddings)
+ */
+function kMeansPlusPlusInit(embeddings: number[][], k: number): number[][] {
+  const n = embeddings.length;
+  const centroids: number[][] = [];
+
+  // Pick first centroid randomly
+  const firstIdx = Math.floor(Math.random() * n);
+  centroids.push([...embeddings[firstIdx]]);
+
+  // Pick remaining centroids
+  for (let c = 1; c < k; c++) {
+    // Compute squared distance from each point to nearest centroid
+    const distances = new Array<number>(n);
+    let totalDist = 0;
+
+    for (let i = 0; i < n; i++) {
+      let minDist = Infinity;
+      for (let j = 0; j < centroids.length; j++) {
+        const dist = euclideanDistanceSquared(embeddings[i], centroids[j]);
+        if (dist < minDist) minDist = dist;
+      }
+      distances[i] = minDist;
+      totalDist += minDist;
+    }
+
+    // Pick next centroid with probability proportional to squared distance
+    let target = Math.random() * totalDist;
+    let picked = 0;
+    for (let i = 0; i < n; i++) {
+      target -= distances[i];
+      if (target <= 0) {
+        picked = i;
+        break;
+      }
+    }
+
+    centroids.push([...embeddings[picked]]);
+  }
+
+  return centroids;
+}
+
+/**
+ * Computes squared Euclidean distance between two vectors.
+ * Skips the sqrt for performance since we only need relative comparisons.
+ * @param a - First vector
+ * @param b - Second vector
+ * @returns Squared Euclidean distance
+ */
+function euclideanDistanceSquared(a: number[], b: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < a.length; i++) {
+    const diff = a[i] - b[i];
+    sum += diff * diff;
+  }
+  return sum;
+}
+
+/**
+ * Parses a Supabase vector string (e.g. "[0.1,0.2,...]") into a number array.
+ * @param embeddingStr - The string representation of the embedding vector
+ * @returns Parsed number array
+ */
+function parseEmbeddingString(embeddingStr: string): number[] {
+  const cleaned = embeddingStr.replace(/^\[|\]$/g, '');
+  return cleaned.split(',').map(Number);
+}

--- a/web/src/types/interests.ts
+++ b/web/src/types/interests.ts
@@ -1,0 +1,51 @@
+/**
+ * Interest Clustering Types
+ *
+ * DTOs for the on-the-fly interest clustering feature that groups
+ * a user's interacted papers by topic similarity.
+ *
+ * Responsibilities:
+ * - Define the shape of a clustered paper for display
+ * - Define the cluster grouping structure
+ * - Define the API response shape
+ */
+
+// ============================================================================
+// INTERFACES
+// ============================================================================
+
+/**
+ * A paper within a cluster, with display metadata.
+ */
+export interface ClusteredPaper {
+  /** UUID of the paper */
+  paperUuid: string;
+  /** Paper title (null if missing) */
+  title: string | null;
+  /** Paper authors (null if missing) */
+  authors: string | null;
+  /** URL-friendly slug (null if no slug exists) */
+  slug: string | null;
+  /** Signed thumbnail URL (null if no thumbnail in storage) */
+  thumbnailUrl: string | null;
+}
+
+/**
+ * A single cluster containing related papers.
+ */
+export interface InterestCluster {
+  /** Zero-based cluster index */
+  clusterIndex: number;
+  /** Papers assigned to this cluster */
+  papers: ClusteredPaper[];
+}
+
+/**
+ * Response from the interests clustering endpoint.
+ */
+export interface InterestClustersResponse {
+  /** Array of clusters, each containing related papers */
+  clusters: InterestCluster[];
+  /** Total number of papers that were clustered */
+  totalPapers: number;
+}


### PR DESCRIPTION
Adds a new /user/interests page to visually explore paper clusters for recommendation algorithm development. Papers the user has interacted with (opened, saved, read) are clustered on-the-fly using k-means on their embeddings.

Key features: adjustable max clusters via slider (1-10, default 5), k-means++ initialization, debounced updates, responsive card grid. Includes API endpoint and service for clustering logic. Marked as internal debug view.

- New page at /user/interests with clustering slider
- K-means algorithm with k-means++ initialization (max 20 iterations)
- API endpoint: GET /api/users/me/interests?maxClusters=N
- Added "My interests" nav item to sidebar and layout tabs