### PR TITLE
Add find similar papers feature to interests view

### DIFF
--- a/web/src/app/api/users/me/interests/search/route.ts
+++ b/web/src/app/api/users/me/interests/search/route.ts
@@ -1,0 +1,77 @@
+/**
+ * Interest Search API Route
+ *
+ * Accepts a centroid embedding and returns papers similar to it,
+ * excluding papers the user has already interacted with.
+ * Returns items in MinimalPaper format compatible with PaperCard.
+ *
+ * Responsibilities:
+ * - POST: Authenticate user, validate embedding, return similar papers
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { searchSimilarPapers } from '@/services/interests.service';
+import type { MinimalPaper } from '@/types/paper';
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface SearchResponse {
+  items: MinimalPaper[];
+}
+
+interface ErrorResponse {
+  error: string;
+}
+
+// ============================================================================
+// MAIN HANDLERS
+// ============================================================================
+
+/**
+ * POST handler for interest-based paper search.
+ * Accepts a centroid embedding and optional limit in the request body.
+ * @param request - The incoming request with { embedding: number[], limit?: number }
+ * @returns { items: MinimalPaper[] } on success, 400/401/500 on error
+ */
+export async function POST(
+  request: NextRequest
+): Promise<NextResponse<SearchResponse | ErrorResponse>> {
+  try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+
+    // Validate embedding
+    if (!Array.isArray(body.embedding) || body.embedding.length === 0) {
+      return NextResponse.json({ error: 'Missing or invalid embedding' }, { status: 400 });
+    }
+
+    // Parse and clamp limit
+    let limit = DEFAULT_LIMIT;
+    if (typeof body.limit === 'number' && body.limit > 0) {
+      limit = Math.min(body.limit, MAX_LIMIT);
+    }
+
+    const items = await searchSimilarPapers(user.id, body.embedding, limit);
+
+    return NextResponse.json({ items });
+  } catch (error) {
+    console.error('Error searching similar papers:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/web/src/app/discover/page.tsx
+++ b/web/src/app/discover/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+/**
+ * Discover Page
+ *
+ * Shows papers similar to a cluster centroid, displayed as a feed using
+ * PaperCard. The centroid embedding is read from sessionStorage (stored
+ * by the interests page when the user clicks "Find similar papers").
+ *
+ * Responsibilities:
+ * - Read centroid from sessionStorage and search for similar papers
+ * - Display results in a feed layout identical to the search page
+ * - Support expanding papers to view summaries
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { ArrowLeft, Loader } from 'lucide-react';
+import type { MinimalPaperItem } from '@/types/paper';
+import { fetchPaperSummary, PaperSummaryResponse } from '@/services/api';
+import PaperCard from '@/components/PaperCard';
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const SESSION_STORAGE_KEY = 'interestSearchCentroid';
+
+// ============================================================================
+// MAIN HANDLERS
+// ============================================================================
+
+/**
+ * Discover page showing papers similar to a cluster centroid.
+ * @returns Feed-style page with similar paper results
+ */
+export default function DiscoverPage() {
+  const [papers, setPapers] = useState<MinimalPaperItem[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [expandedPaperIds, setExpandedPaperIds] = useState<Set<string>>(new Set());
+  const [paperSummaries, setPaperSummaries] = useState<Map<string, PaperSummaryResponse>>(new Map());
+  const [loadingSummaries, setLoadingSummaries] = useState<Set<string>>(new Set());
+
+  // Fetch similar papers on mount
+  useEffect(() => {
+    const run = async () => {
+      const stored = sessionStorage.getItem(SESSION_STORAGE_KEY);
+      if (!stored) {
+        setError('No cluster centroid found. Go to My interests and click "Find similar papers" on a cluster.');
+        setLoading(false);
+        return;
+      }
+
+      let centroid: number[];
+      try {
+        centroid = JSON.parse(stored);
+      } catch {
+        setError('Invalid centroid data.');
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const res = await fetch('/api/users/me/interests/search', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ embedding: centroid }),
+        });
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error || `Search failed (${res.status})`);
+        }
+
+        const data = await res.json();
+        const items = (data.items ?? []) as MinimalPaperItem[];
+        setPapers(items);
+
+        // Preload summaries for all results
+        for (const paper of items) {
+          loadPaperSummary(paper.paperUuid);
+        }
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : 'Failed to search');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    run();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ============================================================================
+  // EVENT HANDLERS
+  // ============================================================================
+
+  /**
+   * Loads and caches a paper summary.
+   * @param paperUuid - UUID of the paper to load
+   */
+  const loadPaperSummary = async (paperUuid: string): Promise<void> => {
+    setLoadingSummaries(prev => new Set(prev).add(paperUuid));
+    try {
+      const summary = await fetchPaperSummary(paperUuid);
+      setPaperSummaries(prev => new Map(prev).set(paperUuid, summary));
+    } catch (e) {
+      console.error('Failed to load summary:', e);
+    } finally {
+      setLoadingSummaries(prev => {
+        const next = new Set(prev);
+        next.delete(paperUuid);
+        return next;
+      });
+    }
+  };
+
+  /**
+   * Toggles expanded state for a paper (only one at a time).
+   * @param paperUuid - UUID of the paper to toggle
+   */
+  const toggleExpanded = useCallback((paperUuid: string): void => {
+    setExpandedPaperIds(prev => {
+      if (prev.has(paperUuid)) {
+        const next = new Set(prev);
+        next.delete(paperUuid);
+        return next;
+      }
+      return new Set([paperUuid]);
+    });
+
+    if (!paperSummaries.has(paperUuid) && !loadingSummaries.has(paperUuid)) {
+      loadPaperSummary(paperUuid);
+    }
+  }, [paperSummaries, loadingSummaries]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ============================================================================
+  // RENDER
+  // ============================================================================
+
+  return (
+    <main className="w-full">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        <a
+          href="/user/interests"
+          className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors mb-4"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to My interests
+        </a>
+
+        <h1 className="text-3xl font-bold mb-2">Discover</h1>
+
+        {/* Debug disclaimer */}
+        <div className="mb-6 px-3 py-2 rounded-md border border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-900/30 text-xs text-amber-800 dark:text-amber-300">
+          Internal debug view -- these are papers from our database most similar to the
+          selected cluster centroid, excluding papers you have already interacted with.
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 rounded-md border border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/40 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center text-sm text-gray-600 dark:text-gray-300">
+            <Loader className="animate-spin w-4 h-4 mr-2" /> Searching for similar papers...
+          </div>
+        ) : papers.length === 0 && !error ? (
+          <div className="text-gray-600 dark:text-gray-300">No similar papers found.</div>
+        ) : (
+          <div className="space-y-4">
+            {papers.map((paper) => (
+              <PaperCard
+                key={paper.paperUuid}
+                paper={paper}
+                isExpanded={expandedPaperIds.has(paper.paperUuid)}
+                isLoadingSummary={loadingSummaries.has(paper.paperUuid)}
+                summary={paperSummaries.get(paper.paperUuid)}
+                onToggleExpand={toggleExpanded}
+                onLoadSummary={loadPaperSummary}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/user/interests/page.tsx
+++ b/web/src/app/user/interests/page.tsx
@@ -15,7 +15,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { useSession } from '@/services/auth';
-import { Loader } from 'lucide-react';
+import { Loader, Search } from 'lucide-react';
 import type { InterestCluster } from '@/types/interests';
 
 // ============================================================================
@@ -93,6 +93,15 @@ export default function UserInterestsPage(): React.JSX.Element {
     setMaxClusters(parseInt(e.target.value, 10));
   };
 
+  /**
+   * Stores a cluster's centroid in sessionStorage and opens the discover page in a new tab.
+   * @param centroid - The cluster centroid embedding vector
+   */
+  const handleFindSimilar = (centroid: number[]): void => {
+    sessionStorage.setItem('interestSearchCentroid', JSON.stringify(centroid));
+    window.open('/discover', '_blank');
+  };
+
   // ============================================================================
   // RENDER
   // ============================================================================
@@ -150,7 +159,11 @@ export default function UserInterestsPage(): React.JSX.Element {
       ) : (
         <div className="space-y-6">
           {clusters.map((cluster) => (
-            <ClusterSection key={cluster.clusterIndex} cluster={cluster} />
+            <ClusterSection
+              key={cluster.clusterIndex}
+              cluster={cluster}
+              onFindSimilar={handleFindSimilar}
+            />
           ))}
         </div>
       )}
@@ -163,11 +176,18 @@ export default function UserInterestsPage(): React.JSX.Element {
 // ============================================================================
 
 /**
- * Renders a single cluster as a section with a heading and a grid of paper cards.
+ * Renders a single cluster as a section with a heading, search button, and a grid of paper cards.
  * @param cluster - The cluster data to display
- * @returns Section with cluster heading and paper grid
+ * @param onFindSimilar - Callback to trigger similar paper search for this cluster's centroid
+ * @returns Section with cluster heading, search button, and paper grid
  */
-function ClusterSection({ cluster }: { cluster: InterestCluster }): React.JSX.Element {
+function ClusterSection({
+  cluster,
+  onFindSimilar,
+}: {
+  cluster: InterestCluster;
+  onFindSimilar: (centroid: number[]) => void;
+}): React.JSX.Element {
   return (
     <div>
       <div className="flex items-center gap-2 mb-2">
@@ -177,6 +197,13 @@ function ClusterSection({ cluster }: { cluster: InterestCluster }): React.JSX.El
         <span className="text-xs text-gray-400 dark:text-gray-500">
           ({cluster.papers.length} {cluster.papers.length === 1 ? 'paper' : 'papers'})
         </span>
+        <button
+          onClick={() => onFindSimilar(cluster.centroid)}
+          className="ml-2 flex items-center gap-1 text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 transition-colors"
+        >
+          <Search className="w-3 h-3" />
+          Find similar papers
+        </button>
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
         {cluster.papers.map((paper) => {

--- a/web/src/services/interests.service.ts
+++ b/web/src/services/interests.service.ts
@@ -17,6 +17,7 @@ import type {
   InterestCluster,
   InterestClustersResponse,
 } from '@/types/interests';
+import type { MinimalPaper } from '@/types/paper';
 
 // ============================================================================
 // CONSTANTS
@@ -27,6 +28,9 @@ const MAX_KMEANS_ITERATIONS = 20;
 
 /** Interaction types to include (excludes 'seen') */
 const INCLUDED_INTERACTION_TYPES = ['expanded', 'read', 'saved'];
+
+/** Default number of similar papers to return in search */
+const DEFAULT_SEARCH_LIMIT = 20;
 
 // ============================================================================
 // MAIN HANDLERS
@@ -112,7 +116,7 @@ export async function getInterestClusters(
   // Step 4: Parse embeddings and run k-means
   const embeddings = papers.map((p) => parseEmbeddingString(p.embedding));
   const k = Math.min(maxClusters, papers.length);
-  const assignments = kMeans(embeddings, k);
+  const { assignments, centroids } = kMeans(embeddings, k);
 
   // Step 5: Group papers by cluster assignment
   const clusterMap = new Map<number, ClusteredPaper[]>();
@@ -140,12 +144,106 @@ export async function getInterestClusters(
   // Build response, re-index clusters sequentially (0, 1, 2, ...)
   const clusters: InterestCluster[] = [];
   let idx = 0;
-  for (const [, papers] of clusterMap) {
-    clusters.push({ clusterIndex: idx, papers });
+  for (const [originalIdx, clusterPapers] of clusterMap) {
+    clusters.push({
+      clusterIndex: idx,
+      papers: clusterPapers,
+      centroid: centroids[originalIdx],
+    });
     idx++;
   }
 
   return { clusters, totalPapers: papers.length };
+}
+
+/**
+ * Searches for papers similar to a given centroid embedding,
+ * excluding papers the user has already interacted with.
+ * @param userId - Supabase auth.uid() of the user
+ * @param embedding - Centroid embedding vector to search with
+ * @param limit - Maximum number of results to return
+ * @returns Ranked list of similar papers as MinimalPaper items
+ */
+export async function searchSimilarPapers(
+  userId: string,
+  embedding: number[],
+  limit: number = DEFAULT_SEARCH_LIMIT
+): Promise<MinimalPaper[]> {
+  const supabase = await createClient();
+
+  // Get papers the user has already interacted with (to exclude)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: interactionRows, error: interactionError } = await (supabase
+    .from('user_interactions') as any)
+    .select('paper_uuid')
+    .eq('user_id', userId)
+    .in('interaction_type', INCLUDED_INTERACTION_TYPES);
+
+  if (interactionError) {
+    throw new Error(`Failed to fetch interactions: ${interactionError.message}`);
+  }
+
+  const excludeUuids = [
+    ...new Set(
+      ((interactionRows ?? []) as { paper_uuid: string }[]).map((r) => r.paper_uuid)
+    ),
+  ];
+
+  // Search for similar papers via the existing RPC
+  const vectorString = `[${embedding.join(',')}]`;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase.rpc as any)(
+    'match_papers_by_embedding',
+    {
+      query_embedding: vectorString,
+      match_count: limit,
+      exclude_uuids: excludeUuids,
+    }
+  );
+
+  if (error) {
+    throw new Error(`match_papers_by_embedding RPC failed: ${error.message}`);
+  }
+
+  const rows = (data ?? []) as {
+    paper_uuid: string;
+    title: string | null;
+    authors: string | null;
+    similarity: number;
+  }[];
+
+  if (rows.length === 0) {
+    return [];
+  }
+
+  // Fetch slugs and thumbnails in parallel
+  const uuids = rows.map((r) => r.paper_uuid);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [slugsResult, thumbnailMap] = await Promise.all([
+    (supabase.from('paper_slugs') as any)
+      .select('paper_uuid, slug')
+      .in('paper_uuid', uuids),
+    getPaperThumbnailUrls(uuids),
+  ]);
+
+  if (slugsResult.error) {
+    throw new Error(`Failed to fetch slugs: ${slugsResult.error.message}`);
+  }
+
+  const slugMap = new Map<string, string>();
+  for (const s of (slugsResult.data ?? []) as { paper_uuid: string; slug: string }[]) {
+    slugMap.set(s.paper_uuid, s.slug);
+  }
+
+  return rows.map((row) => ({
+    paperUuid: row.paper_uuid,
+    title: row.title,
+    authors: row.authors,
+    slug: slugMap.get(row.paper_uuid) ?? null,
+    thumbnailUrl: thumbnailMap.get(row.paper_uuid) ?? null,
+  }));
 }
 
 // ============================================================================
@@ -153,18 +251,31 @@ export async function getInterestClusters(
 // ============================================================================
 
 /**
+ * Result of k-means clustering.
+ */
+interface KMeansResult {
+  /** Cluster assignment for each embedding (index into centroids) */
+  assignments: number[];
+  /** Final centroid vectors */
+  centroids: number[][];
+}
+
+/**
  * Runs k-means clustering on a set of embedding vectors.
  * Uses k-means++ initialization and Lloyd's algorithm.
  * @param embeddings - Array of embedding vectors (all same dimensionality)
  * @param k - Number of clusters to create
- * @returns Array of cluster assignments (one index per embedding)
+ * @returns Cluster assignments and final centroid vectors
  */
-function kMeans(embeddings: number[][], k: number): number[] {
+function kMeans(embeddings: number[][], k: number): KMeansResult {
   const n = embeddings.length;
 
   if (k >= n) {
     // Each paper gets its own cluster
-    return embeddings.map((_, i) => i);
+    return {
+      assignments: embeddings.map((_, i) => i),
+      centroids: embeddings.map((e) => [...e]),
+    };
   }
 
   // K-means++ initialization
@@ -221,7 +332,7 @@ function kMeans(embeddings: number[][], k: number): number[] {
     }
   }
 
-  return assignments;
+  return { assignments, centroids };
 }
 
 /**

--- a/web/src/types/interests.ts
+++ b/web/src/types/interests.ts
@@ -7,7 +7,7 @@
  * Responsibilities:
  * - Define the shape of a clustered paper for display
  * - Define the cluster grouping structure
- * - Define the API response shape
+ * - Define the API response shape for clustering
  */
 
 // ============================================================================
@@ -38,6 +38,8 @@ export interface InterestCluster {
   clusterIndex: number;
   /** Papers assigned to this cluster */
   papers: ClusteredPaper[];
+  /** Centroid embedding vector for similarity search */
+  centroid: number[];
 }
 
 /**


### PR DESCRIPTION
Add centroid-based paper discovery from interest clusters.

Creates a new /discover page that displays papers similar to a selected cluster centroid from the interests page. Users can click 'Find similar papers' on any cluster to open a new tab with a feed of matching papers. Modifies k-means clustering to return final centroid vectors alongside cluster assignments. Adds searchSimilarPapers service function and POST /api/users/me/interests/search endpoint to find papers matching an embedding vector while excluding already-interacted papers.