### PR TITLE
Reduce DB IO: batch author queries, add index, improve S2 retries

### DIFF
--- a/.docs/plans/2026.04.09-dag-fixes-and-db-optimization.md
+++ b/.docs/plans/2026.04.09-dag-fixes-and-db-optimization.md
@@ -1,0 +1,81 @@
+# DAG Fixes and Database IO Optimization
+
+## What was done
+
+### 1. Fixed XCom overflow in `backfill_published_at` DAG
+**File:** `worker/dags/backfill_published_at_dag.py`
+
+The DAG had two tasks: `get_papers_missing_published_at` returned a list of all papers (3,409 dicts) via XCom, and `backfill_dates` consumed it. The serialized list exceeded the MySQL `xcom.value` column limit, causing `Data too long for column 'value'` errors.
+
+**Fix:** Collapsed into a single `backfill_dates` task that queries the DB directly in a `while True` loop, fetching `BATCH_SIZE` (100) papers per iteration. Updated rows disappear from the `published_at IS NULL` filter, so the offset only advances for rows that weren't updated.
+
+**Status:** Deployed and ran successfully — processed 3,409 papers.
+
+### 2. Fixed deadlocks in `reset_stuck_papers` DAG
+**File:** `worker/dags/reset_stuck_papers_dag.py`
+
+The DAG reset all stuck papers in a single transaction. When running concurrently with other DAGs (like `backfill_published_at`), this caused PostgreSQL deadlocks on the `papers` table.
+
+**Fix:** Split into batches of 500 with per-batch commits. All batches are attempted even if one fails; the task raises `RuntimeError` at the end if any batch errored.
+
+**Status:** Deployed and ran successfully — reset 5,099 papers in 10 batches.
+
+### 3. Added configurable parallelism and date filter to `paper_processing_worker` DAG
+**File:** `worker/dags/paper_processing_worker_dag.py`
+
+**Changes:**
+- Added `max_parallel` param (default 4, max 16) — uses an Airflow **pool** (`paper_processing`) to control concurrency at runtime. A `configure_pool` task runs first and resizes the pool based on the param.
+- Added `date_from` / `date_to` params — filters papers by `created_at` in the `_claim_next_job` SQL query.
+- Raised `max_active_tasks` from 4 to 16 as a ceiling (pool is the actual concurrency control).
+
+**Status:** Deployed and tested with `max_parallel=8, date_from=2026-03-23, date_to=2026-03-29`.
+
+### 4. Improved Semantic Scholar retry logic
+**File:** `worker/shared/semantic_scholar/client.py`
+
+S2 API was rate-limiting (429) and failing after only 5 retries with ~3s total backoff. Changed to 10 retries with a "repeat-then-double" pattern: `0.1, 0.1, 0.2, 0.2, 0.4, 0.4, 0.8, 0.8, 1.6, 1.6` (~5.6s total).
+
+```python
+MAX_RETRIES = 10
+RETRY_DELAYS = [0.1 * (2 ** (i // 2)) for i in range(MAX_RETRIES)]
+```
+
+### 5. Root cause identified: Supabase Disk IO Budget exhaustion
+
+Running two servers with 8 parallel workers each caused the Supabase Postgres instance to exhaust its Disk IO Budget. Symptoms:
+- `FOR UPDATE SKIP LOCKED` queries taking 5-10s per row instead of milliseconds
+- S2 API timeouts (waiting on slow DB before/after S2 calls)
+- Overall throughput dropped from ~8 papers/min to ~1 paper/min
+
+The `_claim_next_job` query is particularly IO-heavy: `SELECT id FROM papers WHERE status = 'not_started' ORDER BY created_at DESC LIMIT 1 FOR UPDATE SKIP LOCKED` scans many rows on each call, and is called 500 times sequentially.
+
+### 6. Added composite index on papers(status, created_at DESC)
+**File:** `migrations/versions/20260409_000041_add_papers_status_created_at_index.py`
+
+Alembic migration adding `idx_papers_status_created_at` — lets Postgres use an index scan instead of seq scan + sort for the job claiming query.
+
+**Status:** Migration created, needs to be run against Supabase.
+
+## What is next
+
+### 1. Run the index migration
+Run `alembic upgrade head` against the Supabase database to create the index.
+
+### 2. Deploy and test
+Deploy updated code and run a test batch to verify the IO improvement.
+
+### 3. Consider Supabase compute upgrade
+If optimization isn't enough, the Supabase instance may need a compute upgrade for sustained batch processing. Current IO budget gets exhausted under moderate load (8 parallel workers on one server).
+
+## PR
+
+PR #118: https://github.com/ArthurDevel/OpenPaperDigest/pull/118
+
+Includes commits:
+1. `38b0578` — Batch DAG operations to avoid XCom overflow and deadlocks
+2. `b2adda0` — Add configurable parallelism and date filter to paper processing DAG
+3. `a0e1b55` — Merge main, resolve conflict (keep date filters + ORDER BY created_at DESC)
+
+Not yet committed:
+- S2 retry improvements in `worker/shared/semantic_scholar/client.py`
+- Composite index migration

--- a/migrations/versions/20260409_000041_add_papers_status_created_at_index.py
+++ b/migrations/versions/20260409_000041_add_papers_status_created_at_index.py
@@ -1,0 +1,35 @@
+"""Add composite index on papers(status, created_at DESC) for job claiming.
+
+The _claim_next_job query does:
+  SELECT id FROM papers WHERE status = 'not_started' ORDER BY created_at DESC
+  LIMIT 1 FOR UPDATE SKIP LOCKED
+
+Without this index, Postgres does a seq scan + sort on every call. With 500
+sequential calls per DAG run this exhausts the Supabase Disk IO Budget.
+
+Revision ID: 20260409_000041
+Revises: 20260409_000040
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '20260409_000041'
+down_revision = '20260409_000040'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        'idx_papers_status_created_at',
+        'papers',
+        ['status', sa.text('created_at DESC')],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('idx_papers_status_created_at', table_name='papers')

--- a/worker/dags/paper_processing_worker_dag.py
+++ b/worker/dags/paper_processing_worker_dag.py
@@ -138,24 +138,31 @@ def _refresh_and_score_paper(paper_id: int, author_ids: set) -> None:
 
     if s2_to_db:
         batch_results = fetch_author_stats_batch(list(s2_to_db.keys()))
+        # Build a map of db_id -> stats for bulk update
+        stats_by_db_id = {}
         for stats in batch_results:
             db_id = s2_to_db.get(stats.s2_author_id)
-            if not db_id:
-                continue
+            if db_id:
+                stats_by_db_id[db_id] = stats
+
+        # Update all stale authors in a single session
+        if stats_by_db_id:
             with database_session() as session:
-                record = session.query(AuthorRecord).filter(
-                    AuthorRecord.id == db_id
-                ).first()
-                if record:
+                records = session.query(AuthorRecord).filter(
+                    AuthorRecord.id.in_(stats_by_db_id.keys())
+                ).all()
+                now = datetime.utcnow()
+                for record in records:
+                    stats = stats_by_db_id[record.id]
                     record.name = stats.name
                     record.affiliations = stats.affiliations
                     record.homepage = stats.homepage
                     record.paper_count = stats.paper_count
                     record.citation_count = stats.citation_count
                     record.h_index = stats.h_index
-                    record.stats_updated_at = datetime.utcnow()
+                    record.stats_updated_at = now
 
-    # Compute and write max_author_h_index
+    # Compute max_author_h_index and write to paper signals in one session
     with database_session() as session:
         row = session.query(
             func.max(AuthorRecord.h_index).label("max_h_index"),
@@ -200,13 +207,18 @@ def _link_authors_for_paper(arxiv_id: str) -> None:
         if not record:
             return
 
-        seen_author_ids = set()
-        authors_linked = 0
-        for order, s2_author in enumerate(s2_result.authors, start=1):
-            existing = session.query(AuthorRecord).filter(
-                AuthorRecord.s2_author_id == s2_author.s2_author_id
-            ).first()
+        # Batch-load all existing authors by s2_author_id in one query
+        s2_ids = [a.s2_author_id for a in s2_result.authors]
+        existing_authors = session.query(AuthorRecord).filter(
+            AuthorRecord.s2_author_id.in_(s2_ids)
+        ).all()
+        s2_id_to_author = {a.s2_author_id: a for a in existing_authors}
 
+        # Create missing authors and build full ID map
+        seen_author_ids = set()
+        author_id_order = []  # (author_id, order) pairs to link
+        for order, s2_author in enumerate(s2_result.authors, start=1):
+            existing = s2_id_to_author.get(s2_author.s2_author_id)
             if existing:
                 author_id = existing.id
             else:
@@ -217,17 +229,24 @@ def _link_authors_for_paper(arxiv_id: str) -> None:
                 session.add(new_author)
                 session.flush()
                 author_id = new_author.id
+                s2_id_to_author[s2_author.s2_author_id] = new_author
 
             if author_id in seen_author_ids:
                 continue
             seen_author_ids.add(author_id)
+            author_id_order.append((author_id, order))
 
-            existing_link = session.query(PaperAuthorRecord).filter(
-                PaperAuthorRecord.paper_id == record.id,
-                PaperAuthorRecord.author_id == author_id,
-            ).first()
+        # Batch-load all existing links for this paper in one query
+        existing_links = session.query(PaperAuthorRecord.author_id).filter(
+            PaperAuthorRecord.paper_id == record.id,
+            PaperAuthorRecord.author_id.in_(seen_author_ids),
+        ).all()
+        linked_author_ids = {row[0] for row in existing_links}
 
-            if not existing_link:
+        # Insert only missing links
+        authors_linked = 0
+        for author_id, order in author_id_order:
+            if author_id not in linked_author_ids:
                 session.add(PaperAuthorRecord(
                     paper_id=record.id,
                     author_id=author_id,

--- a/worker/shared/semantic_scholar/client.py
+++ b/worker/shared/semantic_scholar/client.py
@@ -37,9 +37,9 @@ S2_API_BASE = 'https://api.semanticscholar.org/graph/v1'
 # The free-tier rate limit is shared globally across ALL unauthenticated users.
 # Burst fast and retry with exponential backoff — waiting a fixed delay just
 # lets other users consume the pool. Tested in testscripts/7_test_rate_limits.py.
-RETRY_BASE_DELAY = 0.1  # seconds, doubles each retry
-RETRY_BACKOFF = 2.0
-MAX_RETRIES = 5
+MAX_RETRIES = 10
+# Each delay repeated twice before doubling: 0.1, 0.1, 0.2, 0.2, 0.4, 0.4, 0.8, 0.8, 1.6, 1.6
+RETRY_DELAYS = [0.1 * (2 ** (i // 2)) for i in range(MAX_RETRIES)]
 
 # ============================================================================
 # HELPER FUNCTIONS
@@ -65,15 +65,14 @@ def _request_with_retry(method: str, url: str, **kwargs) -> requests.Response:
     @param kwargs: Additional arguments passed to requests.get/post
     @returns Response object
     """
-    delay = RETRY_BASE_DELAY
     for attempt in range(MAX_RETRIES):
         response = getattr(requests, method)(url, **kwargs)
         if response.status_code != 429:
             response.raise_for_status()
             return response
+        delay = RETRY_DELAYS[attempt]
         logger.warning(f"S2 rate limited (429), retrying in {delay:.1f}s (attempt {attempt + 1}/{MAX_RETRIES})")
         time.sleep(delay)
-        delay *= RETRY_BACKOFF
 
     # Final attempt, let it raise
     response = getattr(requests, method)(url, **kwargs)


### PR DESCRIPTION
## Summary
- **Batch author queries**: `_link_authors_for_paper` now loads all existing authors and links in 2 queries instead of per-author (~15 → 2). `_refresh_and_score_paper` updates all stale authors in a single session instead of N separate sessions (~17 → 4).
- **Composite index**: Added `idx_papers_status_created_at` on `(status, created_at DESC)` — the claim query was timing out without it under IO pressure.
- **S2 retry improvements**: 10 retries with repeat-then-double backoff (0.1, 0.1, 0.2, 0.2, 0.4, 0.4, 0.8, 0.8, 1.6, 1.6s).

Reduces ~20 DB round-trips per paper, or ~10,000 fewer per 500-paper DAG run.

## Test plan
- [x] Deployed to Hetzner VPS and triggered paper_processing_worker DAG
- [x] Index created on Supabase, claim query no longer times out
- [x] Papers processing at ~6s each with batched author linking confirmed working
- [x] S2 retry delays verified in client.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)