### PR TITLE
Group active DAG IDs by domain

### DIFF
--- a/worker/dags/daily_arxiv_ingest_dag.py
+++ b/worker/dags/daily_arxiv_ingest_dag.py
@@ -195,7 +195,7 @@ def fetch_new_arxiv_papers(max_results: int = MAX_RESULTS_PER_QUERY) -> List[Dic
 
 
 @dag(
-    dag_id='daily_arxiv_ingest',
+    dag_id='source_daily_arxiv_ingest',
     start_date=pendulum.datetime(2026, 3, 6, tz='UTC'),
     schedule='0 8 * * *',  # Daily at 08:00 UTC (after arXiv daily update)
     catchup=False,

--- a/worker/dags/enrich_s2_paper_data_dag.py
+++ b/worker/dags/enrich_s2_paper_data_dag.py
@@ -525,7 +525,7 @@ def refresh_paper_signals(paper_ids: List[int]) -> Dict[str, int]:
 
 
 @dag(
-    dag_id='enrich_s2_paper_data',
+    dag_id='enrichment_enrich_s2_paper_data',
     start_date=pendulum.datetime(2026, 3, 24, tz='UTC'),
     schedule='0 10 * * *',  # Daily at 10:00 UTC
     catchup=False,

--- a/worker/dags/paper_processing_worker_dag.py
+++ b/worker/dags/paper_processing_worker_dag.py
@@ -365,7 +365,7 @@ async def _process_paper_job_complete(job: JobInfo) -> None:
 
 
 @dag(
-    dag_id="paper_processing_worker",
+    dag_id="processing_paper_processing_worker",
     start_date=pendulum.datetime(2025, 1, 1, tz="UTC"),
     schedule="0 */2 * * *",  # Every 2 hours
     catchup=False,


### PR DESCRIPTION
## Summary
- rename the active source DAG ID to source_daily_arxiv_ingest
- rename the active processing DAG ID to processing_paper_processing_worker
- rename the active enrichment DAG ID to enrichment_enrich_s2_paper_data

## Why
This makes each active DAG sort next to its matching backfill DAG in the Airflow UI.

## Validation
- python -m py_compile worker/dags/daily_arxiv_ingest_dag.py worker/dags/paper_processing_worker_dag.py worker/dags/enrich_s2_paper_data_dag.py