### PR TITLE
Fix null date filters in worker DAG

### DIFF
--- a/worker/dags/paper_processing_worker_dag.py
+++ b/worker/dags/paper_processing_worker_dag.py
@@ -83,6 +83,27 @@ class JobInfo(NamedTuple):
 
 
 # ============================================================================
+# PARAMETER HELPERS
+# ============================================================================
+
+def _normalize_optional_date_param(value: Optional[str]) -> Optional[str]:
+    """
+    Normalize nullable Airflow date params before using them in SQL filters.
+
+    Airflow templating/manual trigger UI can surface empty values as None, "",
+    or stringified nulls like "None".
+    """
+    if value is None:
+        return None
+
+    normalized = str(value).strip()
+    if not normalized or normalized.lower() in {"none", "null"}:
+        return None
+
+    return normalized
+
+
+# ============================================================================
 # DATABASE HELPERS
 # ============================================================================
 
@@ -192,6 +213,9 @@ def _claim_next_job(session: Session, date_from: Optional[str] = None, date_to: 
     Returns:
         Optional[JobInfo]: Next job to process, or None if queue is empty
     """
+    date_from = _normalize_optional_date_param(date_from)
+    date_to = _normalize_optional_date_param(date_to)
+
     # Step 1: Find and lock next available job
     where_clauses = ["status = 'not_started'"]
     params = {}
@@ -432,19 +456,16 @@ def paper_processing_worker_dag():
         print(f"Set pool '{PAPER_PROCESSING_POOL}' to {max_parallel} slots")
 
     @task
-    def claim_available_jobs(date_from: Optional[str] = None, date_to: Optional[str] = None) -> List[int]:
+    def claim_available_jobs(**context) -> List[int]:
         """
         Claim available paper jobs from the queue.
-
-        Args:
-            date_from: Optional start date filter (YYYY-MM-DD)
-            date_to: Optional end date filter (YYYY-MM-DD)
 
         Returns:
             List[int]: List of job IDs for parallel processing (IDs only to avoid XCom size limits)
         """
-        date_from = date_from or None
-        date_to = date_to or None
+        params = context.get("params", {})
+        date_from = _normalize_optional_date_param(params.get("date_from"))
+        date_to = _normalize_optional_date_param(params.get("date_to"))
 
         if date_from or date_to:
             print(f"Date filter: {date_from or 'any'} to {date_to or 'any'}")
@@ -519,10 +540,7 @@ def paper_processing_worker_dag():
     pool_configured = configure_pool(max_parallel="{{ params.max_parallel }}")
 
     # Step 2: Claim available jobs
-    claimed_jobs = claim_available_jobs(
-        date_from="{{ params.date_from }}",
-        date_to="{{ params.date_to }}",
-    )
+    claimed_jobs = claim_available_jobs()
 
     # Step 3: Process each job in parallel using dynamic task mapping
     processing_results = process_single_paper.expand(job_id=claimed_jobs)

--- a/worker/tests/test_paper_processing_worker_dag.py
+++ b/worker/tests/test_paper_processing_worker_dag.py
@@ -1,0 +1,113 @@
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+WORKER_ROOT = Path(__file__).resolve().parents[1]
+if str(WORKER_ROOT) not in sys.path:
+    sys.path.insert(0, str(WORKER_ROOT))
+
+
+class _FakeTaskResult:
+    def __rshift__(self, other):
+        return other
+
+
+class _FakeTaskCallable:
+    def __init__(self, fn):
+        self.fn = fn
+
+    def __call__(self, *args, **kwargs):
+        return _FakeTaskResult()
+
+    def expand(self, **kwargs):
+        return _FakeTaskResult()
+
+
+def _fake_task(*decorator_args, **decorator_kwargs):
+    if decorator_args and callable(decorator_args[0]) and len(decorator_args) == 1 and not decorator_kwargs:
+        return _FakeTaskCallable(decorator_args[0])
+
+    def decorator(fn):
+        return _FakeTaskCallable(fn)
+
+    return decorator
+
+
+def _fake_dag(*args, **kwargs):
+    def decorator(fn):
+        return fn
+
+    return decorator
+
+
+class _FakeParam:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+def _install_module(name: str, **attributes):
+    module = types.ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+_install_module("airflow")
+_install_module("airflow.decorators", dag=_fake_dag, task=_fake_task)
+_install_module("airflow.models")
+_install_module("airflow.models.param", Param=_FakeParam)
+
+_install_module("fitz")
+
+shared_module = _install_module("shared")
+shared_module.__path__ = []
+_install_module("shared.db", SessionLocal=MagicMock())
+shared_arxiv_module = _install_module("shared.arxiv")
+shared_arxiv_module.__path__ = []
+_install_module("shared.arxiv.client", fetch_pdf_for_processing=MagicMock())
+
+papers_module = _install_module("papers")
+papers_module.__path__ = []
+_install_module("papers.models", Paper=MagicMock())
+_install_module("papers.client", save_paper=MagicMock(), create_paper_slug=MagicMock())
+papers_db_module = _install_module("papers.db")
+papers_db_module.__path__ = []
+_install_module("papers.db.models", PaperRecord=type("PaperRecord", (), {}))
+
+paperprocessor_module = _install_module("paperprocessor")
+paperprocessor_module.__path__ = []
+_install_module("paperprocessor.client", process_paper_pdf=MagicMock())
+_install_module("paperprocessor.models", ProcessedDocument=type("ProcessedDocument", (), {}))
+
+users_module = _install_module("users")
+users_module.__path__ = []
+_install_module("users.client", set_requests_processed=MagicMock())
+
+
+from dags.paper_processing_worker_dag import _claim_next_job, _normalize_optional_date_param
+
+
+def test_normalize_optional_date_param_handles_airflow_null_variants():
+    assert _normalize_optional_date_param(None) is None
+    assert _normalize_optional_date_param("") is None
+    assert _normalize_optional_date_param("   ") is None
+    assert _normalize_optional_date_param("None") is None
+    assert _normalize_optional_date_param("null") is None
+    assert _normalize_optional_date_param(" 2026-04-10 ") == "2026-04-10"
+
+
+def test_claim_next_job_ignores_stringified_null_date_filters():
+    session = MagicMock()
+    session.execute.return_value.first.return_value = None
+
+    result = _claim_next_job(session, date_from="None", date_to="null")
+
+    assert result is None
+    statement, params = session.execute.call_args.args
+    assert "created_at >=" not in str(statement)
+    assert "CAST(:date_to AS date)" not in str(statement)
+    assert params == {}


### PR DESCRIPTION
This fixes manual worker DAG runs that passed stringified null date params into the claim query and caused Postgres timestamp parsing failures. The DAG now reads date filters from Airflow params and normalizes empty or stringified null values before building SQL filters. It also adds a regression test covering the normalization and claim-query behavior.